### PR TITLE
Remove redundant code

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ https://user-images.githubusercontent.com/820587/172777357-32c64963-abbe-432c-80
 
 #### module
 ```javascript
-"use strict"
 import RedGPU from "dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/basic/helloWorld/index.js
+++ b/examples/basic/helloWorld/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 const cvs = document.createElement('canvas');
 document.body.appendChild(cvs);

--- a/examples/basic/multiView/index.js
+++ b/examples/basic/multiView/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.3.26 17:3:14
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/basic/scene/index.js
+++ b/examples/basic/scene/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/basic/view/index.js
+++ b/examples/basic/view/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/controller/camera2D/index.js
+++ b/examples/controller/camera2D/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.3.14 19:2:51
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 

--- a/examples/controller/camera3D/index.js
+++ b/examples/controller/camera3D/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.3.23 18:29:56
  *
  */
-"use strict"
 
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 

--- a/examples/controller/obitController/index.js
+++ b/examples/controller/obitController/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.3.14 19:2:51
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/coordinate/getScreenPoint/index.js
+++ b/examples/coordinate/getScreenPoint/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/coordinate/localToWorld/index.js
+++ b/examples/coordinate/localToWorld/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/coordinate/pivotPoint/index.js
+++ b/examples/coordinate/pivotPoint/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/coordinate/pivotPoint_2d/index.js
+++ b/examples/coordinate/pivotPoint_2d/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.3.14 19:2:51
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/coordinate/screenToWorld/index.js
+++ b/examples/coordinate/screenToWorld/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.3.14 19:2:51
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/coordinate/worldToLocal/index.js
+++ b/examples/coordinate/worldToLocal/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/index.js
+++ b/examples/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../dist/RedGPU.min.mjs";
 import exampleList from "./exampleList.js";
 

--- a/examples/light/ambientLight/index.js
+++ b/examples/light/ambientLight/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict";
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/light/directionalLight/index.js
+++ b/examples/light/directionalLight/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/light/pointLight/index.js
+++ b/examples/light/pointLight/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/loader/gltf/index.js
+++ b/examples/loader/gltf/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/loader/gltfComplex/index.js
+++ b/examples/loader/gltfComplex/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/material/bitmapMaterial/index.js
+++ b/examples/material/bitmapMaterial/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/material/colorMaterial/index.js
+++ b/examples/material/colorMaterial/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/material/colorPhongMaterial/index.js
+++ b/examples/material/colorPhongMaterial/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/material/colorPhongTextureMaterial/index.js
+++ b/examples/material/colorPhongTextureMaterial/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/material/environmentMaterial/index.js
+++ b/examples/material/environmentMaterial/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/material/flatModeOfMaterial/index.js
+++ b/examples/material/flatModeOfMaterial/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/material/refractionMaterial/index.js
+++ b/examples/material/refractionMaterial/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/material/spriteSheetMaterial/index.js
+++ b/examples/material/spriteSheetMaterial/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/material/standardMaterial/index.js
+++ b/examples/material/standardMaterial/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/mouseEvent/mouseEvent/index.js
+++ b/examples/mouseEvent/mouseEvent/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 // import RedGPU from "../../../dist/RedGPU.min.mjs";
 import RedGPU from "../../../src/RedGPU.js";
 

--- a/examples/mouseEvent/mouseEventInMultiView/index.js
+++ b/examples/mouseEvent/mouseEventInMultiView/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/object3D/axis/index.js
+++ b/examples/object3D/axis/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/object3D/grid/index.js
+++ b/examples/object3D/grid/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/object3D/lineBezier/index.js
+++ b/examples/object3D/lineBezier/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/object3D/lineCatmullRom/index.js
+++ b/examples/object3D/lineCatmullRom/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/object3D/lineLinear/index.js
+++ b/examples/object3D/lineLinear/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/object3D/mesh/index.js
+++ b/examples/object3D/mesh/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/object3D/skyBox/index.js
+++ b/examples/object3D/skyBox/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/object3D/sprite3D/index.js
+++ b/examples/object3D/sprite3D/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/object3D/targetTo/index.js
+++ b/examples/object3D/targetTo/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/object3D/text/index.js
+++ b/examples/object3D/text/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/particle/particle/index.js
+++ b/examples/particle/particle/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/postEffect/postEffect/index.js
+++ b/examples/postEffect/postEffect/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/postEffect/postEffect_bloom/index.js
+++ b/examples/postEffect/postEffect_bloom/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/postEffect/postEffect_blur/index.js
+++ b/examples/postEffect/postEffect_blur/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/postEffect/postEffect_blurX/index.js
+++ b/examples/postEffect/postEffect_blurX/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/postEffect/postEffect_blurY/index.js
+++ b/examples/postEffect/postEffect_blurY/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/postEffect/postEffect_brightnessContrast/index.js
+++ b/examples/postEffect/postEffect_brightnessContrast/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/postEffect/postEffect_convolution/index.js
+++ b/examples/postEffect/postEffect_convolution/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/postEffect/postEffect_dof/index.js
+++ b/examples/postEffect/postEffect_dof/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/postEffect/postEffect_film/index.js
+++ b/examples/postEffect/postEffect_film/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/postEffect/postEffect_gaussianBlur/index.js
+++ b/examples/postEffect/postEffect_gaussianBlur/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/postEffect/postEffect_gray/index.js
+++ b/examples/postEffect/postEffect_gray/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/postEffect/postEffect_halfTone/index.js
+++ b/examples/postEffect/postEffect_halfTone/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/postEffect/postEffect_hueSaturation/index.js
+++ b/examples/postEffect/postEffect_hueSaturation/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/postEffect/postEffect_invert/index.js
+++ b/examples/postEffect/postEffect_invert/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/postEffect/postEffect_pixelize/index.js
+++ b/examples/postEffect/postEffect_pixelize/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/postEffect/postEffect_threshold/index.js
+++ b/examples/postEffect/postEffect_threshold/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/postEffect/postEffect_vignetting/index.js
+++ b/examples/postEffect/postEffect_vignetting/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/postEffect/postEffect_zoomBlur/index.js
+++ b/examples/postEffect/postEffect_zoomBlur/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/primitive/box/index.js
+++ b/examples/primitive/box/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/primitive/cylinder/index.js
+++ b/examples/primitive/cylinder/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/primitive/plane/index.js
+++ b/examples/primitive/plane/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/primitive/sphere/index.js
+++ b/examples/primitive/sphere/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/examples/texture/bitmapTexture/index.js
+++ b/examples/texture/bitmapTexture/index.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.2.28 21:0:29
  *
  */
-"use strict"
 import RedGPU from "../../../dist/RedGPU.min.mjs";
 
 const cvs = document.createElement('canvas');

--- a/src/RedGPUContext.js
+++ b/src/RedGPUContext.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.3.26 17:47:56
  *
  */
-"use strict";
 import DetectorGPU from "./base/detect/DetectorGPU.js";
 import ShareGLSL from "./base/ShareGLSL.js";
 import Sampler from "./resources/Sampler.js";

--- a/src/RedGPUContext.js
+++ b/src/RedGPUContext.js
@@ -19,7 +19,7 @@ let setGlobalResizeEvent = function () {
 
   }
   window.addEventListener('resize', resize);
-  requestAnimationFrame(e=>{
+  requestAnimationFrame(_ => {
     resize()
   })
 };
@@ -65,10 +65,8 @@ let checkTwgsl = function () {
      // await import(/* webpackIgnore: true */ 'https://redcamel.github.io/RedGPU/libs/twgsl.js');
       console.log('twgsl',twgsl)
       twgslLib = twgsl;
-      resolve();
-    } else {
-      resolve();
     }
+    resolve();
   });
 };
 
@@ -89,7 +87,6 @@ export default class RedGPUContext {
       console.log('glslang', glslang);
       console.log(this);
       this.#detector = new DetectorGPU(this);
-      let state = true;
       if (navigator.gpu) {
         navigator.gpu.requestAdapter(
           {
@@ -211,7 +208,6 @@ export default class RedGPUContext {
 
               });
           }).catch(error => {
-          state = false;
           initFunc(false, error);
         });
       } else {

--- a/src/Scene.js
+++ b/src/Scene.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import DisplayContainer from "./base/DisplayContainer.js";
 import UTIL from "./util/UTIL.js";
 import DirectionalLight from "./light/DirectionalLight.js";

--- a/src/View.js
+++ b/src/View.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import UTIL from "./util/UTIL.js";
 import TypeSize from "./resources/TypeSize.js";
 import ShareGLSL from "./base/ShareGLSL.js";

--- a/src/base/BaseLight.js
+++ b/src/base/BaseLight.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import UUID from "./UUID.js";
 import UTIL from "../util/UTIL.js";
 import ColorMaterial from "../material/ColorMaterial.js";

--- a/src/base/BaseMaterial.js
+++ b/src/base/BaseMaterial.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import ShaderModule_GLSL from "../resources/ShaderModule_GLSL.js";
 import UUID from "./UUID.js";
 import UniformBuffer from "../buffer/UniformBuffer.js";

--- a/src/base/BaseObject3D.js
+++ b/src/base/BaseObject3D.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.3.26 17:3:14
  *
  */
-"use strict";
 import UniformBuffer from "../buffer/UniformBuffer.js";
 import DisplayContainer from "./DisplayContainer.js";
 import PipelineBasic from "./pipeline/PipelineBasic.js";

--- a/src/base/BasePostEffect.js
+++ b/src/base/BasePostEffect.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseMaterial from "../base/BaseMaterial.js";
 import Mix from "./Mix.js";
 import Mesh from "../object3D/Mesh.js";

--- a/src/base/BaseTexture.js
+++ b/src/base/BaseTexture.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import UUID from "./UUID.js";
 import BitmapTexture from "../resources/BitmapTexture.js";
 

--- a/src/base/DisplayContainer.js
+++ b/src/base/DisplayContainer.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 
 import UUID from "./UUID.js";
 import UTIL from "../util/UTIL.js";

--- a/src/base/Mix.js
+++ b/src/base/Mix.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.1.20 18:6:15
  *
  */
-"use strict";
 import UTIL from "../util/UTIL.js";
 
 let float1_Float32Array = new Float32Array(1);

--- a/src/base/RedGPUWorker.js
+++ b/src/base/RedGPUWorker.js
@@ -6,15 +6,13 @@
  *
  */
 
-"use strict";
 
 function createWorker(f) {
   return new Worker(URL.createObjectURL(new Blob([`(${f})()`], {type: 'application/javascript'})));
 }
 
 const workerImage = createWorker(async () => {
-  "use strict";
-  /////////////////////////////////////////////////////////////////////////////
+    /////////////////////////////////////////////////////////////////////////////
   let getImage = (_ => {
     let nextHighestPowerOfTwo = (function () {
       let i;
@@ -101,8 +99,7 @@ const workerImage = createWorker(async () => {
   });
 });
 const workerGLSLCompile = createWorker(async () => {
-  "use strict";
-  let glslangModule = await import(/* webpackIgnore: true */ 'https://unpkg.com/@webgpu/glslang@0.0.15/dist/web-devel/glslang.js');
+    let glslangModule = await import(/* webpackIgnore: true */ 'https://unpkg.com/@webgpu/glslang@0.0.15/dist/web-devel/glslang.js');
   let glslang = await glslangModule.default();
   let twgslLib
   let checkTwgsl = async function () {

--- a/src/base/ShareGLSL.js
+++ b/src/base/ShareGLSL.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 export default class ShareGLSL {
   static MESH_UNIFORM_POOL_NUM = 25;
   static GLSL_VERSION = '#version 460';
@@ -50,9 +49,9 @@ export default class ShareGLSL {
         targetSampler='targetSampler'
     )=>{
         return `
-        normalize(${vNormal}) 
+        normalize(${vNormal})
         * texture(
-            sampler2D(${targetDisplacementTexture}, ${targetSampler}), 
+            sampler2D(${targetDisplacementTexture}, ${targetSampler}),
             ${targetUV} + vec2(
                 ${displacementFlowSpeedX} * (systemUniforms.time/1000.0),
                 ${displacementFlowSpeedY} * (systemUniforms.time/1000.0)
@@ -104,7 +103,7 @@ export default class ShareGLSL {
 	        float spotLightCount;
 	        DirectionalLight directionalLightList[MAX_DIRECTIONAL_LIGHT];
 	        PointLight pointLightList[MAX_POINT_LIGHT];
-	        AmbientLight ambientLight;	        
+	        AmbientLight ambientLight;
 	        SpotLight spotLightList[MAX_SPOT_LIGHT];
 	        vec2 resolution;
 	        vec3 cameraPosition;
@@ -113,7 +112,7 @@ export default class ShareGLSL {
         vec4 la = systemUniforms.ambientLight.color * systemUniforms.ambientLight.intensity;
         vec4 calcDirectionalLight(
             vec4 diffuseColor,
-            vec3 N,		
+            vec3 N,
 			float loopNum,
 			DirectionalLight[MAX_DIRECTIONAL_LIGHT] lightList,
 			float shininess,
@@ -123,18 +122,18 @@ export default class ShareGLSL {
 		){
 		    vec4 ld = vec4(0.0, 0.0, 0.0, 1.0);
 		    vec4 ls = vec4(0.0, 0.0, 0.0, 1.0);
-		    
-		    vec3 L;	
+
+		    vec3 L;
 		    vec4 lightColor;
-		    
+
 		    float lambertTerm;
 		    float intensity;
 		    float specular;
-		    		    
+
 		    DirectionalLight lightInfo;
 		    for(int i = 0; i< loopNum; i++){
 		        lightInfo = lightList[i];
-			    L = normalize(-lightInfo.position);	
+			    L = normalize(-lightInfo.position);
 			    lightColor = lightInfo.color;
 			    lambertTerm = dot(N,-L);
 			    intensity = lightInfo.intensity;
@@ -149,7 +148,7 @@ export default class ShareGLSL {
 		/////////////////////////////////////////////////////////////////////////////
 		vec4 calcPointLight(
             vec4 diffuseColor,
-            vec3 N,		
+            vec3 N,
 			float loopNum,
 			PointLight[MAX_POINT_LIGHT] lightList,
 			float shininess,
@@ -160,14 +159,14 @@ export default class ShareGLSL {
 		){
 			vec4 ld = vec4(0.0, 0.0, 0.0, 1.0);
 		    vec4 ls = vec4(0.0, 0.0, 0.0, 1.0);
-		    
-		    vec3 L;	
+
+		    vec3 L;
 		    vec4 lightColor;
-		    
+
 		    float lambertTerm;
 		    float intensity;
 		    float specular;
-		  
+
 		    PointLight lightInfo;
 		    float distanceLength ;
 		    float attenuation;
@@ -176,15 +175,15 @@ export default class ShareGLSL {
 		        L = -lightInfo.position + vVertexPosition;
 			    distanceLength = abs(length(L));
 			    if(lightInfo.radius> distanceLength){
-			        L = normalize(L);	
+			        L = normalize(L);
               lightColor = lightInfo.color;
               lambertTerm = dot(N,-L);
               intensity = lightInfo.intensity;
               if(lambertTerm > 0.0){
-                  attenuation = clamp(1.0 - distanceLength*distanceLength/(lightInfo.radius*lightInfo.radius), 0.0, 1.0); 
+                  attenuation = clamp(1.0 - distanceLength*distanceLength/(lightInfo.radius*lightInfo.radius), 0.0, 1.0);
                   attenuation *= attenuation;
             	    ld += lightColor* diffuseColor * lambertTerm * intensity * attenuation;
-            	 
+
                   specular = pow( max(dot(reflect(L, N), -L), 0.0), shininess) * specularPower * specularTextureValue;
                   ls +=  specularColor * specular * intensity * attenuation;
               }
@@ -194,7 +193,7 @@ export default class ShareGLSL {
 		}
 		vec4 calcSpotLight(
             vec4 diffuseColor,
-            vec3 N,		
+            vec3 N,
 			float loopNum,
 			SpotLight[MAX_SPOT_LIGHT] lightList,
 			float shininess,
@@ -205,14 +204,14 @@ export default class ShareGLSL {
 		){
 			vec4 ld = vec4(0.0, 0.0, 0.0, 1.0);
 		    vec4 ls = vec4(0.0, 0.0, 0.0, 1.0);
-		    
-		    vec3 L;	
+
+		    vec3 L;
 		    vec4 lightColor;
-		    
+
 		    float lambertTerm;
 		    float intensity;
 		    float specular;
-		  
+
 		    SpotLight lightInfo;
 	        float distanceLength ;
 		    float attenuation;
@@ -221,19 +220,19 @@ export default class ShareGLSL {
 		        L = -lightInfo.position + vVertexPosition;
 			    distanceLength = abs(length(L));
 			    vec3 spotDirection = vec3(0.1,-1,0);
-			    L = normalize(L);	
+			    L = normalize(L);
 			    lambertTerm = dot(N,-L);
 				float spotEffect = dot(normalize(spotDirection),L);
                 lightColor = lightInfo.color;
 		        float limit = 10;
 		        float inLight = step(cos(limit * 3.141592653589793/180), spotEffect);
                 float light = inLight * spotEffect;
-			    if(lambertTerm > 0 && spotEffect > lightInfo.cutoff ){			     
+			    if(lambertTerm > 0 && spotEffect > lightInfo.cutoff ){
 			        if(spotEffect > cos(limit * 3.141592653589793/180) ){
 				        spotEffect = pow(spotEffect, lightInfo.exponent);
 		                attenuation = spotEffect * light ;
-					    intensity = lightInfo.intensity;					 
-				     
+					    intensity = lightInfo.intensity;
+
 						ld += lightColor * diffuseColor * intensity * attenuation;
 						specular = pow( max(dot(reflect(L, N), -L), 0.0), shininess) * specularPower * specularTextureValue;
 						ls +=  specularColor * specular * intensity * attenuation ;
@@ -251,7 +250,7 @@ export default class ShareGLSL {
 		`,
     perturb_normal: `
 		vec3 perturb_normal( vec3 N, vec3 V, vec2 texcoord, vec3 normalColor , float normalPower)
-		{	   
+		{
 			vec3 map = normalColor;
 			map =  map * 255./127. - 128./127.;
 			map.xy *= -normalPower;
@@ -262,17 +261,17 @@ export default class ShareGLSL {
     cotangent_frame: `
 		mat3 cotangent_frame(vec3 N, vec3 p, vec2 uv)
 		{
-		
+
 			vec3 dp1 = dFdx( p );
 			vec3 dp2 = dFdy( p );
 			vec2 duv1 = dFdx( uv );
 			vec2 duv2 = dFdy( uv );
-			
+
 			vec3 dp2perp = cross( dp2, N );
 			vec3 dp1perp = cross( N, dp1 );
 			vec3 T = dp2perp * duv1.x + dp1perp * duv2.x;
 			vec3 B = dp2perp * duv1.y + dp1perp * duv2.y;
-			
+
 			float invmax = inversesqrt( max( dot(T,T), dot(B,B) ) );
 			return mat3( T * invmax, B * invmax, N );
 		}

--- a/src/base/UUID.js
+++ b/src/base/UUID.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 let _UUID = 1;
 export default class UUID {
   constructor() {this._UUID = _UUID++;}

--- a/src/base/baseGeometry.js
+++ b/src/base/baseGeometry.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import UUID from "../base/UUID.js";
 
 export default class baseGeometry extends UUID {

--- a/src/base/detect/DetectorGPU.js
+++ b/src/base/detect/DetectorGPU.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import RedGPUContext from "../../RedGPUContext.js";
 
 export default class DetectorGPU {

--- a/src/base/gl-matrix-min.js
+++ b/src/base/gl-matrix-min.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.1.20 18:6:15
  *
  */
-"use strict";
 var n = 1e-6, a = "undefined" != typeof Float32Array ? Float32Array : Array, r = Math.random;
 var u = Math.PI / 180;
 Math.hypot || (Math.hypot = function () {

--- a/src/base/pipeline/PipelineBasic.js
+++ b/src/base/pipeline/PipelineBasic.js
@@ -6,8 +6,6 @@
  *
  */
 
-"use strict";
-
 import UUID from "../UUID.js";
 
 

--- a/src/base/pipeline/PipelineParticle.js
+++ b/src/base/pipeline/PipelineParticle.js
@@ -6,8 +6,6 @@
  *
  */
 
-"use strict";
-
 import UUID from "../UUID.js";
 
 

--- a/src/base/pipeline/PipelinePostEffect.js
+++ b/src/base/pipeline/PipelinePostEffect.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 
 import UUID from "../UUID.js";
 

--- a/src/buffer/BindGroup.js
+++ b/src/buffer/BindGroup.js
@@ -6,8 +6,6 @@
  *
  */
 
-"use strict";
-
 import RedGPUContext from "../RedGPUContext.js";
 
 export default class BindGroup {

--- a/src/buffer/Buffer.js
+++ b/src/buffer/Buffer.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import UUID from "../base/UUID.js";
 import RedGPUContext from "../RedGPUContext.js";
 

--- a/src/buffer/UniformBuffer.js
+++ b/src/buffer/UniformBuffer.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import UniformBufferDescriptor from "./UniformBufferDescriptor.js";
 import UTIL from "../util/UTIL.js";
 import RedGPUContext from "../RedGPUContext.js";

--- a/src/buffer/UniformBufferDescriptor.js
+++ b/src/buffer/UniformBufferDescriptor.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 
 import TypeSize from "../resources/TypeSize.js";
 import UUID from "../base/UUID.js";

--- a/src/controller/Camera2D.js
+++ b/src/controller/Camera2D.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseObject3D from "../base/BaseObject3D.js";
 
 export default class Camera2D extends BaseObject3D {

--- a/src/controller/Camera3D.js
+++ b/src/controller/Camera3D.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseObject3D from "../base/BaseObject3D.js";
 import glMatrix from "../base/gl-matrix-min.js";
 

--- a/src/controller/ObitController.js
+++ b/src/controller/ObitController.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import Camera3D from "./Camera3D.js";
 import glMatrix from "../base/gl-matrix-min.js";
 

--- a/src/geometry/Geometry.js
+++ b/src/geometry/Geometry.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import RedGPUContext from "../RedGPUContext.js";
 import baseGeometry from "../base/baseGeometry.js";
 

--- a/src/geometry/InterleaveInfo.js
+++ b/src/geometry/InterleaveInfo.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import TypeSize from "../resources/TypeSize.js";
 import RedGPUContext from "../RedGPUContext.js";
 

--- a/src/light/AmbientLight.js
+++ b/src/light/AmbientLight.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseLight from "../base/BaseLight.js";
 
 export default class AmbientLight extends BaseLight {

--- a/src/light/DirectionalLight.js
+++ b/src/light/DirectionalLight.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseLight from "../base/BaseLight.js";
 import Mesh from "../object3D/Mesh.js";
 import Sphere from "../primitives/Sphere.js";

--- a/src/light/PointLight.js
+++ b/src/light/PointLight.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseLight from "../base/BaseLight.js";
 import Mesh from "../object3D/Mesh.js";
 import Sphere from "../primitives/Sphere.js";

--- a/src/light/SpotLight.js
+++ b/src/light/SpotLight.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseLight from "../base/BaseLight.js";
 import Mesh from "../object3D/Mesh.js";
 import Cylinder from "../primitives/Cylinder.js";

--- a/src/loader/TextureLoader.js
+++ b/src/loader/TextureLoader.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.1.16 21:13:13
  *
  */
-"use strict";
 import UUID from "../base/UUID.js";
 import BitmapTexture from "../resources/BitmapTexture.js";
 import BitmapCubeTexture from "../resources/BitmapCubeTexture.js";

--- a/src/loader/gltf/GLTFLoader.js
+++ b/src/loader/gltf/GLTFLoader.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import UUID from "../../base/UUID.js";
 import Mesh from "../../object3D/Mesh.js";
 import UTIL from "../../util/UTIL.js";

--- a/src/loader/gltf/cls/AccessorInfo_GLTF.js
+++ b/src/loader/gltf/cls/AccessorInfo_GLTF.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import UTIL from "../../../util/UTIL.js";
 import WEBGL_COMPONENT_TYPES from "./WEBGL_COMPONENT_TYPES.js";
 

--- a/src/loader/gltf/cls/MorphInfo_GLTF.js
+++ b/src/loader/gltf/cls/MorphInfo_GLTF.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.1.20 18:6:15
  *
  */
-"use strict";
 import AccessorInfo_GLTF from "./AccessorInfo_GLTF.js";
 import parseAttributeInfo_GLTF from "../func/parseAttributeInfo_GLTF.js";
 import parseSparse_GLTF from "../func/parseSparse_GLTF.js";

--- a/src/loader/gltf/cls/WEBGL_COMPONENT_TYPES.js
+++ b/src/loader/gltf/cls/WEBGL_COMPONENT_TYPES.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.1.20 18:6:15
  *
  */
-"use strict";
 const WEBGL_COMPONENT_TYPES = {
   5120: Int8Array,
   5121: Uint8Array,

--- a/src/loader/gltf/func/makeInterleaveData_GLTF.js
+++ b/src/loader/gltf/func/makeInterleaveData_GLTF.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.1.16 21:13:13
  *
  */
-"use strict";
 let makeInterleaveData_GLTF = function (interleaveData, vertices, verticesColor_0, normalData, uvs, uvs1, jointWeights, joints, tangents) {
   let i = 0, len = vertices.length / 3;
   let idx = 0;

--- a/src/loader/gltf/func/makeMesh_GLTF.js
+++ b/src/loader/gltf/func/makeMesh_GLTF.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import AccessorInfo_GLTF from "../cls/AccessorInfo_GLTF.js";
 import PBRMaterial_System from "../../../material/system/PBRMaterial_System.js";
 import UTIL from "../../../util/UTIL.js";

--- a/src/loader/gltf/func/parseAnimation_GLTF.js
+++ b/src/loader/gltf/func/parseAnimation_GLTF.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import RedGPUContext from "../../../RedGPUContext.js";
 import AccessorInfo_GLTF from "../cls/AccessorInfo_GLTF.js";
 

--- a/src/loader/gltf/func/parseAttributeInfo_GLTF.js
+++ b/src/loader/gltf/func/parseAttributeInfo_GLTF.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import UTIL from "../../../util/UTIL.js";
 
 let parseAttributeInfo_GLTF = function (redGLTFLoader, json, key, accessorInfo, vertices, uvs, uvs1, normals, jointWeights, joints, verticesColor_0, tangents) {

--- a/src/loader/gltf/func/parseCameras_GLTF.js
+++ b/src/loader/gltf/func/parseCameras_GLTF.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import RedGPUContext from "../../../RedGPUContext.js";
 import Camera3D from "../../../controller/Camera3D.js";
 

--- a/src/loader/gltf/func/parseIndicesInfo_GLTF.js
+++ b/src/loader/gltf/func/parseIndicesInfo_GLTF.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 let parseIndicesInfo_GLTF = function (redGLTFLoader, json, accessorInfo, indices) {
   let tBYTES_PER_ELEMENT = accessorInfo['componentType_BYTES_PER_ELEMENT'];
   let tBufferURIDataView = accessorInfo['bufferURIDataView'];

--- a/src/loader/gltf/func/parseMaterialInfo_GLTF.js
+++ b/src/loader/gltf/func/parseMaterialInfo_GLTF.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import RedGPUContext from "../../../RedGPUContext.js";
 import PBRMaterial_System from "../../../material/system/PBRMaterial_System.js";
 import Sampler from "../../../resources/Sampler.js";

--- a/src/loader/gltf/func/parseNode_GLTF.js
+++ b/src/loader/gltf/func/parseNode_GLTF.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import parseTRSAndMATRIX_GLTF from "./parseTRSAndMATRIX_GLTF.js";
 import parseSkin_GLTF from "./parseSkin_GLTF.js";
 import Mesh from "../../../object3D/Mesh.js";

--- a/src/loader/gltf/func/parseScene_GLTF.js
+++ b/src/loader/gltf/func/parseScene_GLTF.js
@@ -6,8 +6,6 @@
  *
  */
 
-"use strict";
-
 import RedGPUContext from "../../../RedGPUContext.js";
 import parseNode_GLTF from "./parseNode_GLTF.js";
 

--- a/src/loader/gltf/func/parseSkin_GLTF.js
+++ b/src/loader/gltf/func/parseSkin_GLTF.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import AccessorInfo_GLTF from "../cls/AccessorInfo_GLTF.js";
 
 let checkJoint = function (redGLTFLoader, skinInfo, nodes, v) {

--- a/src/loader/gltf/func/parseSparse_GLTF.js
+++ b/src/loader/gltf/func/parseSparse_GLTF.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import WEBGL_COMPONENT_TYPES from "../cls/WEBGL_COMPONENT_TYPES.js";
 
 let parseSparse_GLTF = function (redGLTFLoader, key, tAccessors, json, vertices, uvs, uvs1, normals, jointWeights, joints) {

--- a/src/loader/gltf/func/parseTRSAndMATRIX_GLTF.js
+++ b/src/loader/gltf/func/parseTRSAndMATRIX_GLTF.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.3.26 17:3:14
  *
  */
-"use strict";
 import glMatrix from "../../../base/gl-matrix-min.js";
 import UTIL from "../../../util/UTIL.js";
 

--- a/src/material/BitmapMaterial.js
+++ b/src/material/BitmapMaterial.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.1.20 18:6:15
  *
  */
-"use strict";
 import BaseMaterial from "../base/BaseMaterial.js";
 import ShareGLSL from "../base/ShareGLSL.js";
 import Mix from "../base/Mix.js";
@@ -27,7 +26,7 @@ export default class BitmapMaterial extends Mix.mix(
 	layout( location = 2 ) in vec2 uv;
 	layout( location = 0 ) out vec3 vNormal;
 	layout( location = 1 ) out vec2 vUV;
-	layout( location = 2 ) out float vMouseColorID;	
+	layout( location = 2 ) out float vMouseColorID;
 	layout( location = 3 ) out float vSumOpacity;
 	void main() {
 		vNormal = normal;
@@ -42,7 +41,7 @@ export default class BitmapMaterial extends Mix.mix(
 	const float TRUTHY = 1.0;
 	layout( location = 0 ) in vec3 vNormal;
 	layout( location = 1 ) in vec2 vUV;
-	layout( location = 2 ) in float vMouseColorID;	
+	layout( location = 2 ) in float vMouseColorID;
 	layout( location = 3 ) in float vSumOpacity;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 0 ) uniform FragmentUniforms {
         float alpha;
@@ -59,7 +58,7 @@ export default class BitmapMaterial extends Mix.mix(
 		outColor = diffuseColor;
 		outColor.a *= fragmentUniforms.alpha * vSumOpacity;
 		out_MouseColorID_Depth = vec4(vMouseColorID, gl_FragCoord.z/gl_FragCoord.w, 0.0, 0.0);
-		
+
 	}
 `;
   static PROGRAM_OPTION_LIST = {

--- a/src/material/ColorMaterial.js
+++ b/src/material/ColorMaterial.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import TypeSize from "../resources/TypeSize.js";
 import BaseMaterial from "../base/BaseMaterial.js";
 import ShareGLSL from "../base/ShareGLSL.js";
@@ -23,13 +22,13 @@ export default class ColorMaterial extends Mix.mix(
 	${ShareGLSL.GLSL_SystemUniforms_vertex.meshUniforms}
 	layout( location = 0 ) in vec3 position;
 	layout( location = 1 ) in vec3 normal;
-	layout( location = 0 ) out float vMouseColorID;	
+	layout( location = 0 ) out float vMouseColorID;
 	layout( location = 1 ) out float vSumOpacity;
 	void main() {
 		vMouseColorID = meshUniforms.mouseColorID;
 		vSumOpacity = meshUniforms.sumOpacity;
 		gl_Position = systemUniforms.perspectiveMTX * systemUniforms.cameraMTX * meshMatrixUniforms.modelMatrix[ int(meshUniforms.index) ] * vec4(position,1.0);
-	
+
 	}
 	`;
   static fragmentShaderGLSL = `
@@ -47,9 +46,9 @@ export default class ColorMaterial extends Mix.mix(
 	void main() {
 		outColor = fragmentUniforms.color;
 		outColor.a *= vSumOpacity;
-		outColor.a *= fragmentUniforms.alpha;	
+		outColor.a *= fragmentUniforms.alpha;
 		out_MouseColorID_Depth = vec4(vMouseColorID, gl_FragCoord.z/gl_FragCoord.w, 0.0, 0.0);
-		
+
 	}
 	`;
   static PROGRAM_OPTION_LIST = {vertex: [], fragment: []};

--- a/src/material/ColorPhongMaterial.js
+++ b/src/material/ColorPhongMaterial.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import TypeSize from "../resources/TypeSize.js";
 import ShareGLSL from "../base/ShareGLSL.js";
 
@@ -43,7 +42,7 @@ export default class ColorPhongMaterial extends Mix.mix(
 	${ShareGLSL.GLSL_SystemUniforms_fragment.systemUniforms}
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 0 ) uniform FragmentUniforms {
         vec4 color;
-        float shininess; 
+        float shininess;
         float specularPower;
 	    vec4 specularColor;
         float alpha;
@@ -52,22 +51,22 @@ export default class ColorPhongMaterial extends Mix.mix(
     } fragmentUniforms;
 	layout( location = 0 ) in vec3 vNormal;
 	layout( location = 1 ) in vec4 vVertexPosition;
-	layout( location = 2 ) in float vMouseColorID;	
+	layout( location = 2 ) in float vMouseColorID;
 	layout( location = 3 ) in float vSumOpacity;
-	layout( location = 0 ) out vec4 outColor;	
+	layout( location = 0 ) out vec4 outColor;
 	layout( location = 1 ) out vec4 out_MouseColorID_Depth;
 	void main() {
 		float testAlpha = fragmentUniforms.color.a * vSumOpacity;
 
 		vec3 N = normalize(vNormal);
 		if(fragmentUniforms.useFlatMode == TRUTHY) N = getFlatNormal(vVertexPosition.xyz);
-		
+
 		float specularTextureValue = 1.0;
-		
-		vec4 finalColor = 
+
+		vec4 finalColor =
 		calcDirectionalLight(
 			fragmentUniforms.color,
-			N,		
+			N,
 			systemUniforms.directionalLightCount,
 			systemUniforms.directionalLightList,
 			fragmentUniforms.shininess,
@@ -78,7 +77,7 @@ export default class ColorPhongMaterial extends Mix.mix(
 		+
 	    calcPointLight(
 			fragmentUniforms.color,
-			N,		
+			N,
 			systemUniforms.pointLightCount,
 			systemUniforms.pointLightList,
 			fragmentUniforms.shininess,
@@ -88,12 +87,12 @@ export default class ColorPhongMaterial extends Mix.mix(
 			vVertexPosition.xyz
 		)
 		+ la;
-			
+
 		finalColor.a = testAlpha;
 		outColor = finalColor;
 		outColor.a *= fragmentUniforms.alpha;
 		out_MouseColorID_Depth = vec4(vMouseColorID, gl_FragCoord.z/gl_FragCoord.w, 0.0, 0.0);
-		
+
 	}
 `;
   // static PROGRAM_OPTION_LIST = {vertex: [], fragment: ['useFlatMode']};

--- a/src/material/ColorPhongTextureMaterial.js
+++ b/src/material/ColorPhongTextureMaterial.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.3.14 19:2:51
  *
  */
-"use strict";
 import TypeSize from "../resources/TypeSize.js";
 import ShareGLSL from "../base/ShareGLSL.js";
 import Mix from "../base/Mix.js";
@@ -26,7 +25,7 @@ export default class ColorPhongTextureMaterial extends Mix.mix(
   static vertexShaderGLSL = `
 	${ShareGLSL.GLSL_VERSION}
 	${ShareGLSL.GLSL_SystemUniforms_vertex.systemUniforms}
-    
+
     ${ShareGLSL.GLSL_SystemUniforms_vertex.meshUniforms}
 	layout( location = 0 ) in vec3 position;
 	layout( location = 1 ) in vec3 normal;
@@ -34,7 +33,7 @@ export default class ColorPhongTextureMaterial extends Mix.mix(
 	layout( location = 0 ) out vec3 vNormal;
 	layout( location = 1 ) out vec2 vUV;
 	layout( location = 2 ) out vec4 vVertexPosition;
-	layout( location = 3 ) out float vMouseColorID;	
+	layout( location = 3 ) out float vMouseColorID;
 	layout( location = 4 ) out float vSumOpacity;
 	layout( set = ${ShareGLSL.SET_INDEX_VertexUniforms}, binding = 0 ) uniform VertexUniforms {
         float displacementFlowSpeedX;
@@ -42,7 +41,7 @@ export default class ColorPhongTextureMaterial extends Mix.mix(
         float displacementPower;
         float __displacementTextureRenderYn;
     } vertexUniforms;
-    
+
     layout( set = ${ShareGLSL.SET_INDEX_VertexUniforms}, binding = 1 ) uniform sampler uSampler;
 	layout( set = ${ShareGLSL.SET_INDEX_VertexUniforms}, binding = 2) uniform texture2D uDisplacementTexture;
 	void main() {
@@ -63,7 +62,7 @@ export default class ColorPhongTextureMaterial extends Mix.mix(
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 3 ) uniform FragmentUniforms {
         vec4 color;
         float normalPower;
-        float shininess; 
+        float shininess;
         float specularPower;
 	    vec4 specularColor;
 	    float emissivePower;
@@ -77,7 +76,7 @@ export default class ColorPhongTextureMaterial extends Mix.mix(
 	layout( location = 0 ) in vec3 vNormal;
 	layout( location = 1 ) in vec2 vUV;
 	layout( location = 2 ) in vec4 vVertexPosition;
-	layout( location = 3 ) in float vMouseColorID;	
+	layout( location = 3 ) in float vMouseColorID;
 	layout( location = 4 ) in float vSumOpacity;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 4 ) uniform sampler uNormalSampler;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 5 ) uniform texture2D uNormalTexture;
@@ -86,25 +85,25 @@ export default class ColorPhongTextureMaterial extends Mix.mix(
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 8 ) uniform sampler uEmissiveSampler;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 9 ) uniform texture2D uEmissiveTexture;
 	layout( location = 0 ) out vec4 outColor;
-	
+
 	layout( location = 1 ) out vec4 out_MouseColorID_Depth;
-	
+
 	void main() {
 		float testAlpha = fragmentUniforms.color.a * vSumOpacity;
-		
+
 		vec3 N = normalize(vNormal);
 		vec4 normalColor = vec4(0.0);
 		if(fragmentUniforms.__normalTextureRenderYn == TRUTHY) normalColor = texture(sampler2D(uNormalTexture, uNormalSampler), vUV) ;
 		if(fragmentUniforms.useFlatMode == TRUTHY) N = getFlatNormal(vVertexPosition.xyz);
 		if(fragmentUniforms.__normalTextureRenderYn == TRUTHY) N = perturb_normal(N, vVertexPosition.xyz, vUV, normalColor.rgb, fragmentUniforms.normalPower) ;
-		
+
 		float specularTextureValue = 1.0;
 		if(fragmentUniforms.__specularTextureRenderYn == TRUTHY) specularTextureValue = texture(sampler2D(uSpecularTexture, uSpecularSampler), vUV).r ;
-		
-		vec4 finalColor = 
+
+		vec4 finalColor =
 		calcDirectionalLight(
 			fragmentUniforms.color,
-			N,		
+			N,
 			systemUniforms.directionalLightCount,
 			systemUniforms.directionalLightList,
 			fragmentUniforms.shininess,
@@ -115,7 +114,7 @@ export default class ColorPhongTextureMaterial extends Mix.mix(
 	    +
 	    calcPointLight(
 			fragmentUniforms.color,
-			N,		
+			N,
 			systemUniforms.pointLightCount,
 			systemUniforms.pointLightList,
 			fragmentUniforms.shininess,
@@ -130,12 +129,12 @@ export default class ColorPhongTextureMaterial extends Mix.mix(
 			vec4 emissiveColor = texture(sampler2D(uEmissiveTexture, uEmissiveSampler), vUV);
 			finalColor.rgb += emissiveColor.rgb * fragmentUniforms.emissivePower;
 		}
-		
+
 		finalColor.a = testAlpha;
 		outColor = finalColor;
 		outColor.a *= fragmentUniforms.alpha;
 		out_MouseColorID_Depth = vec4(vMouseColorID, gl_FragCoord.z/gl_FragCoord.w, 0.0, 0.0);
-		
+
 	}
 `;
   static PROGRAM_OPTION_LIST = {

--- a/src/material/EnvironmentMaterial.js
+++ b/src/material/EnvironmentMaterial.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.1.20 18:6:15
  *
  */
-"use strict";
 import TypeSize from "../resources/TypeSize.js";
 import BaseMaterial from "../base/BaseMaterial.js";
 import ShareGLSL from "../base/ShareGLSL.js";
@@ -28,25 +27,25 @@ export default class EnvironmentMaterial extends Mix.mix(
 	${ShareGLSL.GLSL_VERSION}
     ${ShareGLSL.GLSL_SystemUniforms_vertex.systemUniforms}
     ${ShareGLSL.GLSL_SystemUniforms_vertex.meshUniforms}
-         
+
 	layout( location = 0 ) in vec3 position;
 	layout( location = 1 ) in vec3 normal;
 	layout( location = 2 ) in vec2 uv;
 	layout( location = 0 ) out vec3 vNormal;
 	layout( location = 1 ) out vec2 vUV;
-	layout( location = 2 ) out vec4 vVertexPosition;	
-	layout( location = 3 ) out float vMouseColorID;	
+	layout( location = 2 ) out vec4 vVertexPosition;
+	layout( location = 3 ) out float vMouseColorID;
 	layout( location = 4 ) out float vSumOpacity;
 	layout( set = ${ShareGLSL.SET_INDEX_VertexUniforms}, binding = 0 ) uniform VertexUniforms {
         float displacementFlowSpeedX;
         float displacementFlowSpeedY;
-        float displacementPower;        
+        float displacementPower;
 		float __displacementTextureRenderYn;
     } vertexUniforms;
-	
+
 	layout( set = ${ShareGLSL.SET_INDEX_VertexUniforms}, binding = 1 ) uniform sampler uDisplacementSampler;
 	layout( set = ${ShareGLSL.SET_INDEX_VertexUniforms}, binding = 2 ) uniform texture2D uDisplacementTexture;
-	void main() {		
+	void main() {
 		vVertexPosition = meshMatrixUniforms.modelMatrix[ int(meshUniforms.index) ] * vec4(position, 1.0);
 		vNormal = (meshMatrixUniforms.normalMatrix[ int(meshUniforms.index) ] * vec4(normal,1.0)).xyz;
 		vUV = uv;
@@ -54,8 +53,8 @@ export default class EnvironmentMaterial extends Mix.mix(
 		vSumOpacity = meshUniforms.sumOpacity;
 		if(vertexUniforms.__displacementTextureRenderYn == TRUTHY) vVertexPosition.xyz += ${ShareGLSL.GLSL_SystemUniforms_vertex.calcDisplacement('vNormal', 'vertexUniforms.displacementFlowSpeedX', 'vertexUniforms.displacementFlowSpeedY', 'vertexUniforms.displacementPower', 'uv', 'uDisplacementTexture', 'uDisplacementSampler')}
 		gl_Position = systemUniforms.perspectiveMTX * systemUniforms.cameraMTX * vVertexPosition;
-	
-	
+
+
 	}
 	`;
   static fragmentShaderGLSL = `
@@ -65,7 +64,7 @@ export default class EnvironmentMaterial extends Mix.mix(
 	${ShareGLSL.GLSL_SystemUniforms_fragment.perturb_normal}
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 3 ) uniform FragmentUniforms {
         float normalPower;
-        float shininess; 
+        float shininess;
         float specularPower;
 	    vec4 specularColor;
 	    float emissivePower;
@@ -89,7 +88,7 @@ export default class EnvironmentMaterial extends Mix.mix(
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 5 ) uniform texture2D uDiffuseTexture;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 6 ) uniform sampler uNormalSampler;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 7 ) uniform texture2D uNormalTexture;
-	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 8 ) uniform sampler uSpecularSampler;	
+	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 8 ) uniform sampler uSpecularSampler;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 9 ) uniform texture2D uSpecularTexture;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 10 ) uniform sampler uEmissiveSampler;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 11 ) uniform texture2D uEmissiveTexture;
@@ -101,29 +100,29 @@ export default class EnvironmentMaterial extends Mix.mix(
 		float testAlpha = 0.0;
 		vec4 diffuseColor = vec4(0.0);
 		if(fragmentUniforms.__diffuseTextureRenderYn == TRUTHY) diffuseColor = texture(sampler2D(uDiffuseTexture, uDiffuseSampler), vUV) ;
-		
-		
+
+
 	    vec3 N = normalize(vNormal);
 		vec4 normalColor = vec4(0.0);
 		if(fragmentUniforms.__normalTextureRenderYn == TRUTHY) normalColor = texture(sampler2D(uNormalTexture, uNormalSampler), vUV) ;
 		if(fragmentUniforms.useFlatMode == TRUTHY) N = getFlatNormal(vVertexPosition.xyz);
 		if(fragmentUniforms.__normalTextureRenderYn == TRUTHY) N = perturb_normal(N, vVertexPosition.xyz, vUV, normalColor.rgb, fragmentUniforms.normalPower) ;
-	
+
 		if(fragmentUniforms.__environmentTextureRenderYn == TRUTHY) {
 			vec3 R = reflect( vVertexPosition.xyz - systemUniforms.cameraPosition, N);
 			vec4 reflectionColor = texture(samplerCube(uEnvironmentTexture,uEnvironmentSampler), R);
 			diffuseColor = mix(diffuseColor, reflectionColor, fragmentUniforms.environmentPower);
 		}
-		
+
 		testAlpha = diffuseColor.a ;
-		
+
 		float specularTextureValue = 1.0;
 		if(fragmentUniforms.__specularTextureRenderYn == TRUTHY) specularTextureValue = texture(sampler2D(uSpecularTexture, uSpecularSampler), vUV).r ;
-		
-		vec4 finalColor = 
+
+		vec4 finalColor =
 		calcDirectionalLight(
 			diffuseColor,
-			N,		
+			N,
 			systemUniforms.directionalLightCount,
 			systemUniforms.directionalLightList,
 			fragmentUniforms.shininess,
@@ -134,7 +133,7 @@ export default class EnvironmentMaterial extends Mix.mix(
 		+
 		calcPointLight(
 			diffuseColor,
-			N,		
+			N,
 			systemUniforms.pointLightCount,
 			systemUniforms.pointLightList,
 			fragmentUniforms.shininess,
@@ -144,19 +143,19 @@ export default class EnvironmentMaterial extends Mix.mix(
 			vVertexPosition.xyz
 		)
 		+ la;
-		
+
 		if(fragmentUniforms.__emissiveTextureRenderYn == TRUTHY) {
 			vec4 emissiveColor = texture(sampler2D(uEmissiveTexture, uEmissiveSampler), vUV);
 			finalColor.rgb += emissiveColor.rgb * fragmentUniforms.emissivePower;
 		}
-		
-		
+
+
 		finalColor.a = testAlpha;
 		outColor = finalColor;
 		outColor.a *= fragmentUniforms.alpha * vSumOpacity;
 
 		out_MouseColorID_Depth = vec4(vMouseColorID, gl_FragCoord.z/gl_FragCoord.w, 0.0, 0.0);
-		
+
 	}
 `;
   static PROGRAM_OPTION_LIST = {

--- a/src/material/RefractionMaterial.js
+++ b/src/material/RefractionMaterial.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import TypeSize from "../resources/TypeSize.js";
 import BaseMaterial from "../base/BaseMaterial.js";
 import ShareGLSL from "../base/ShareGLSL.js";
@@ -29,14 +28,14 @@ export default class RefractionMaterial extends Mix.mix(
 	${ShareGLSL.GLSL_VERSION}
     ${ShareGLSL.GLSL_SystemUniforms_vertex.systemUniforms}
     ${ShareGLSL.GLSL_SystemUniforms_vertex.meshUniforms}
-         
+
 	layout( location = 0 ) in vec3 position;
 	layout( location = 1 ) in vec3 normal;
 	layout( location = 2 ) in vec2 uv;
 	layout( location = 0 ) out vec3 vNormal;
 	layout( location = 1 ) out vec2 vUV;
-	layout( location = 2 ) out vec4 vVertexPosition;	
-	layout( location = 3 ) out float vMouseColorID;	
+	layout( location = 2 ) out vec4 vVertexPosition;
+	layout( location = 3 ) out float vMouseColorID;
 	layout( location = 4 ) out float vSumOpacity;
 	layout( set = ${ShareGLSL.SET_INDEX_VertexUniforms}, binding = 0 ) uniform VertexUniforms {
         float displacementFlowSpeedX;
@@ -44,17 +43,17 @@ export default class RefractionMaterial extends Mix.mix(
         float displacementPower;
         float __displacementTextureRenderYn;
     } vertexUniforms;
-	
+
 	layout( set = ${ShareGLSL.SET_INDEX_VertexUniforms}, binding = 1 ) uniform sampler uDisplacementSampler;
 	layout( set = ${ShareGLSL.SET_INDEX_VertexUniforms}, binding = 2 ) uniform texture2D uDisplacementTexture;
-	void main() {		
+	void main() {
 		vVertexPosition = meshMatrixUniforms.modelMatrix[ int(meshUniforms.index) ] * vec4(position, 1.0);
 		vNormal = (meshMatrixUniforms.normalMatrix[ int(meshUniforms.index) ] * vec4(normal,1.0)).xyz;
 		vUV = uv;
 		vMouseColorID = meshUniforms.mouseColorID;
 		vSumOpacity = meshUniforms.sumOpacity;
 		if(vertexUniforms.__displacementTextureRenderYn == TRUTHY) vVertexPosition.xyz += ${ShareGLSL.GLSL_SystemUniforms_vertex.calcDisplacement('vNormal', 'vertexUniforms.displacementFlowSpeedX', 'vertexUniforms.displacementFlowSpeedY', 'vertexUniforms.displacementPower', 'uv', 'uDisplacementTexture', 'uDisplacementSampler')}
-		gl_Position = systemUniforms.perspectiveMTX * systemUniforms.cameraMTX * vVertexPosition;		
+		gl_Position = systemUniforms.perspectiveMTX * systemUniforms.cameraMTX * vVertexPosition;
 	}
 	`;
   static fragmentShaderGLSL = `
@@ -64,7 +63,7 @@ export default class RefractionMaterial extends Mix.mix(
 	${ShareGLSL.GLSL_SystemUniforms_fragment.perturb_normal}
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 3 ) uniform FragmentUniforms {
         float normalPower;
-        float shininess; 
+        float shininess;
         float specularPower;
 	    vec4 specularColor;
 	    float emissivePower;
@@ -89,42 +88,42 @@ export default class RefractionMaterial extends Mix.mix(
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 5 ) uniform texture2D uDiffuseTexture;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 6 ) uniform sampler uNormalSampler;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 7 ) uniform texture2D uNormalTexture;
-	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 8 ) uniform sampler uSpecularSampler;	
+	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 8 ) uniform sampler uSpecularSampler;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 9 ) uniform texture2D uSpecularTexture;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 10 ) uniform sampler uEmissiveSampler;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 11 ) uniform texture2D uEmissiveTexture;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 12 ) uniform sampler uRefractionSampler;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 13 ) uniform textureCube uRefractionTexture;
 	layout( location = 0 ) out vec4 outColor;
-	
+
 	layout( location = 1 ) out vec4 out_MouseColorID_Depth;
 	void main() {
 		float testAlpha = 0.0;
 		vec4 diffuseColor = vec4(0.0);
 		if(fragmentUniforms.__diffuseTextureRenderYn == TRUTHY) diffuseColor = texture(sampler2D(uDiffuseTexture, uDiffuseSampler), vUV) ;
-			
+
 	    vec3 N = normalize(vNormal);
 		vec4 normalColor = vec4(0.0);
 		if(fragmentUniforms.__normalTextureRenderYn == TRUTHY) normalColor = texture(sampler2D(uNormalTexture, uNormalSampler), vUV) ;
 		if(fragmentUniforms.useFlatMode == TRUTHY) N = getFlatNormal(vVertexPosition.xyz);
 		if(fragmentUniforms.__normalTextureRenderYn == TRUTHY) N = perturb_normal(N, vVertexPosition.xyz, vUV, normalColor.rgb, fragmentUniforms.normalPower) ;
-	
+
 		if(fragmentUniforms.__refractionTextureRenderYn == TRUTHY) {
 			vec3 I = normalize(vVertexPosition.xyz - systemUniforms.cameraPosition);
 			vec3 R = refract(I, N, fragmentUniforms.refractionRatio);
 			vec4 refractionColor = texture(samplerCube(uRefractionTexture,uRefractionSampler), R);
 			diffuseColor = mix(diffuseColor, refractionColor, fragmentUniforms.refractionPower);
 		}
-		
+
 		testAlpha = diffuseColor.a;
-		
+
 		float specularTextureValue = 1.0;
 		if(fragmentUniforms.__specularTextureRenderYn == TRUTHY) specularTextureValue = texture(sampler2D(uSpecularTexture, uSpecularSampler), vUV).r ;
-		
-		vec4 finalColor = 
+
+		vec4 finalColor =
 		calcDirectionalLight(
 			diffuseColor,
-			N,		
+			N,
 			systemUniforms.directionalLightCount,
 			systemUniforms.directionalLightList,
 			fragmentUniforms.shininess,
@@ -135,7 +134,7 @@ export default class RefractionMaterial extends Mix.mix(
 		+
 		calcPointLight(
 			diffuseColor,
-			N,		
+			N,
 			systemUniforms.pointLightCount,
 			systemUniforms.pointLightList,
 			fragmentUniforms.shininess,
@@ -145,17 +144,17 @@ export default class RefractionMaterial extends Mix.mix(
 			vVertexPosition.xyz
 		)
 		+ la;
-		
+
 		if(fragmentUniforms.__emissiveTextureRenderYn == TRUTHY) {
 			vec4 emissiveColor = texture(sampler2D(uEmissiveTexture, uEmissiveSampler), vUV);
 			finalColor.rgb += emissiveColor.rgb * fragmentUniforms.emissivePower;
 		}
-		
+
 		finalColor.a = testAlpha;
 		outColor = finalColor;
 		outColor.a *= fragmentUniforms.alpha * vSumOpacity;
 		out_MouseColorID_Depth = vec4(vMouseColorID, gl_FragCoord.z/gl_FragCoord.w, 0.0, 0.0);
-		
+
 	}
 `;
   static PROGRAM_OPTION_LIST = {

--- a/src/material/Sprite3DMaterial.js
+++ b/src/material/Sprite3DMaterial.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseMaterial from "../base/BaseMaterial.js";
 import ShareGLSL from "../base/ShareGLSL.js";
 import Mix from "../base/Mix.js";
@@ -29,7 +28,7 @@ export default class Sprite3DMaterial extends Mix.mix(
 	layout( location = 0 ) out vec3 vNormal;
 	layout( location = 1 ) out vec2 vUV;
 	layout( location = 2 ) out float vMouseColorID;
-	layout( location = 3 ) out float vSumOpacity;	
+	layout( location = 3 ) out float vSumOpacity;
 	layout( set = ${ShareGLSL.SET_INDEX_VertexUniforms}, binding = 0 ) uniform VertexUniforms {
         float useFixedScale;
     } vertexUniforms;
@@ -51,8 +50,8 @@ export default class Sprite3DMaterial extends Mix.mix(
 	const float TRUTHY = 1.0;
 	layout( location = 0 ) in vec3 vNormal;
 	layout( location = 1 ) in vec2 vUV;
-	layout( location = 2 ) in float vMouseColorID;	
-	layout( location = 3 ) in float vSumOpacity;	
+	layout( location = 2 ) in float vMouseColorID;
+	layout( location = 3 ) in float vSumOpacity;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 1 ) uniform FragmentUniforms {
         float alpha;
         //
@@ -61,7 +60,7 @@ export default class Sprite3DMaterial extends Mix.mix(
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 2 ) uniform sampler uSampler;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 3 ) uniform texture2D uDiffuseTexture;
 	layout( location = 0 ) out vec4 outColor;
-	
+
 	layout( location = 1 ) out vec4 out_MouseColorID_Depth;
 	void main() {
 		vec4 diffuseColor = vec4(0.0);
@@ -69,7 +68,7 @@ export default class Sprite3DMaterial extends Mix.mix(
 		outColor = diffuseColor;
 		outColor.a *= fragmentUniforms.alpha * vSumOpacity;
 		out_MouseColorID_Depth = vec4(vMouseColorID, gl_FragCoord.z/gl_FragCoord.w, 0.0, 0.0);
-		
+
 	}
 `;
   static PROGRAM_OPTION_LIST = {

--- a/src/material/SpriteSheetAction.js
+++ b/src/material/SpriteSheetAction.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import UUID from "../base/UUID.js";
 
 export default class SpriteSheetAction extends UUID {

--- a/src/material/SpriteSheetMaterial.js
+++ b/src/material/SpriteSheetMaterial.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseMaterial from "../base/BaseMaterial.js";
 import ShareGLSL from "../base/ShareGLSL.js";
 import Mix from "../base/Mix.js";
@@ -33,18 +32,18 @@ export default class SpriteSheetMaterial extends Mix.mix(
 	layout( location = 0 ) out vec3 vNormal;
 	layout( location = 1 ) out vec2 vUV;
 	layout( location = 2 ) out float vMouseColorID;
-	layout( location = 3 ) out float vSumOpacity;	
+	layout( location = 3 ) out float vSumOpacity;
 	void main() {
 		vUV = uv;
 		vUV = vec2(
 			vUV.s * vertexUniforms.sheetRect.x + vertexUniforms.sheetRect.z,
 			vUV.t * vertexUniforms.sheetRect.y -vertexUniforms.sheetRect.w
-		);	
-		vSumOpacity = meshUniforms.sumOpacity;	
+		);
+		vSumOpacity = meshUniforms.sumOpacity;
 		gl_Position = systemUniforms.perspectiveMTX * systemUniforms.cameraMTX * meshMatrixUniforms.modelMatrix[ int(meshUniforms.index) ] * vec4(position,1.0);
 		vNormal = normal;
 		vMouseColorID = meshUniforms.mouseColorID;
-	
+
 	}
 	`;
   static fragmentShaderGLSL = `
@@ -52,8 +51,8 @@ export default class SpriteSheetMaterial extends Mix.mix(
 	const float TRUTHY = 1.0;
 	layout( location = 0 ) in vec3 vNormal;
 	layout( location = 1 ) in vec2 vUV;
-	layout( location = 2 ) in float vMouseColorID;	
-	layout( location = 3 ) in float vSumOpacity;	
+	layout( location = 2 ) in float vMouseColorID;
+	layout( location = 3 ) in float vSumOpacity;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 1 ) uniform FragmentUniforms {
         float alpha;
         //
@@ -62,18 +61,18 @@ export default class SpriteSheetMaterial extends Mix.mix(
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 2 ) uniform sampler uSampler;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 3 ) uniform texture2D uDiffuseTexture;
 	layout( location = 0 ) out vec4 outColor;
-	
+
 	layout( location = 1 ) out vec4 out_MouseColorID_Depth;
 	void main() {
 		vec4 diffuseColor = vec4(0.0);
 		if(fragmentUniforms.__diffuseTextureRenderYn == TRUTHY) diffuseColor = texture(sampler2D(uDiffuseTexture, uSampler), vUV) ;
-		
+
 		if(diffuseColor.a<0.05) discard;
-			
+
 		outColor = diffuseColor;
 		outColor.a *= fragmentUniforms.alpha * vSumOpacity;
 		out_MouseColorID_Depth = vec4(vMouseColorID, gl_FragCoord.z/gl_FragCoord.w, 0.0, 0.0);
-		
+
 	}
 `;
   static PROGRAM_OPTION_LIST = {

--- a/src/material/StandardMaterial.js
+++ b/src/material/StandardMaterial.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import TypeSize from "../resources/TypeSize.js";
 import BaseMaterial from "../base/BaseMaterial.js";
 import ShareGLSL from "../base/ShareGLSL.js";
@@ -28,14 +27,14 @@ export default class StandardMaterial extends Mix.mix(
 	${ShareGLSL.GLSL_VERSION}
     ${ShareGLSL.GLSL_SystemUniforms_vertex.systemUniforms}
     ${ShareGLSL.GLSL_SystemUniforms_vertex.meshUniforms}
-         
+
 	layout( location = 0 ) in vec3 position;
 	layout( location = 1 ) in vec3 normal;
 	layout( location = 2 ) in vec2 uv;
 	layout( location = 0 ) out vec3 vNormal;
 	layout( location = 1 ) out vec2 vUV;
-	layout( location = 2 ) out vec4 vVertexPosition;	
-	layout( location = 3 ) out float vMouseColorID;	
+	layout( location = 2 ) out vec4 vVertexPosition;
+	layout( location = 3 ) out float vMouseColorID;
 	layout( location = 4 ) out float vSumOpacity;
 	layout( set = ${ShareGLSL.SET_INDEX_VertexUniforms}, binding = 0 ) uniform VertexUniforms {
         float displacementFlowSpeedX;
@@ -43,10 +42,10 @@ export default class StandardMaterial extends Mix.mix(
         float displacementPower;
         float __displacementTextureRenderYn;
     } vertexUniforms;
-	
+
 	layout( set = ${ShareGLSL.SET_INDEX_VertexUniforms}, binding = 1 ) uniform sampler uSampler;
 	layout( set = ${ShareGLSL.SET_INDEX_VertexUniforms}, binding = 2 ) uniform texture2D uDisplacementTexture;
-	void main() {		
+	void main() {
 		vVertexPosition = meshMatrixUniforms.modelMatrix[ int(meshUniforms.index) ] * vec4(position, 1.0);
 		vNormal = (meshMatrixUniforms.normalMatrix[ int(meshUniforms.index) ] * vec4(normal,1.0)).xyz;
 		vUV = uv;
@@ -54,8 +53,8 @@ export default class StandardMaterial extends Mix.mix(
 		vSumOpacity = meshUniforms.sumOpacity;
 		if(vertexUniforms.__displacementTextureRenderYn == TRUTHY) vVertexPosition.xyz += ${ShareGLSL.GLSL_SystemUniforms_vertex.calcDisplacement('vNormal', 'vertexUniforms.displacementFlowSpeedX', 'vertexUniforms.displacementFlowSpeedY', 'vertexUniforms.displacementPower', 'uv', 'uDisplacementTexture', 'uSampler')}
 		gl_Position = systemUniforms.perspectiveMTX * systemUniforms.cameraMTX * vVertexPosition;
-	
-	
+
+
 	}
 	`;
   static fragmentShaderGLSL = `
@@ -65,7 +64,7 @@ export default class StandardMaterial extends Mix.mix(
 	${ShareGLSL.GLSL_SystemUniforms_fragment.perturb_normal}
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 3 ) uniform FragmentUniforms {
         float normalPower;
-        float shininess; 
+        float shininess;
         float specularPower;
 	    vec4 specularColor;
 	    float emissivePower;
@@ -81,41 +80,41 @@ export default class StandardMaterial extends Mix.mix(
 	layout( location = 0 ) in vec3 vNormal;
 	layout( location = 1 ) in vec2 vUV;
 	layout( location = 2 ) in vec4 vVertexPosition;
-	layout( location = 3 ) in float vMouseColorID;	
+	layout( location = 3 ) in float vMouseColorID;
 	layout( location = 4 ) in float vSumOpacity;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 4 ) uniform sampler uDiffuseSampler;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 5 ) uniform texture2D uDiffuseTexture;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 6 ) uniform sampler uNormalSampler;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 7 ) uniform texture2D uNormalTexture;
-	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 8 ) uniform sampler uSpecularSampler;	
+	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 8 ) uniform sampler uSpecularSampler;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 9 ) uniform texture2D uSpecularTexture;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 10 ) uniform sampler uEmissiveSampler;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 11 ) uniform texture2D uEmissiveTexture;
 	layout( location = 0 ) out vec4 outColor;
-	
+
 	layout( location = 1 ) out vec4 out_MouseColorID_Depth;
 
 	void main() {
 		float testAlpha = 0.0;
 		vec4 diffuseColor = vec4(0.0);
 		if(fragmentUniforms.__diffuseTextureRenderYn == TRUTHY) diffuseColor = texture(sampler2D(uDiffuseTexture, uDiffuseSampler), vUV) ;
-		
-		
+
+
 	    vec3 N = normalize(vNormal);
 		vec4 normalColor = vec4(0.0);
 		if(fragmentUniforms.__normalTextureRenderYn == TRUTHY) normalColor = texture(sampler2D(uNormalTexture, uNormalSampler), vUV) ;
 		if(fragmentUniforms.useFlatMode == TRUTHY) N = getFlatNormal(vVertexPosition.xyz);
 		if(fragmentUniforms.__normalTextureRenderYn == TRUTHY) N = perturb_normal(N, vVertexPosition.xyz, vUV, normalColor.rgb, fragmentUniforms.normalPower) ;
-	
+
 		testAlpha = diffuseColor.a;
-	
+
 		float specularTextureValue = 1.0;
 		if(fragmentUniforms.__specularTextureRenderYn == TRUTHY) specularTextureValue = texture(sampler2D(uSpecularTexture, uSpecularSampler), vUV).r ;
-		
-		vec4 finalColor = 
+
+		vec4 finalColor =
 		calcDirectionalLight(
 			diffuseColor,
-			N,		
+			N,
 			systemUniforms.directionalLightCount,
 			systemUniforms.directionalLightList,
 			fragmentUniforms.shininess,
@@ -126,7 +125,7 @@ export default class StandardMaterial extends Mix.mix(
 		+
 		calcPointLight(
 			diffuseColor,
-			N,		
+			N,
 			systemUniforms.pointLightCount,
 			systemUniforms.pointLightList,
 			fragmentUniforms.shininess,
@@ -136,17 +135,17 @@ export default class StandardMaterial extends Mix.mix(
 			vVertexPosition.xyz
 		)
 		+ la;
-		
+
 		if(fragmentUniforms.__emissiveTextureRenderYn == TRUTHY) {
 			vec4 emissiveColor = texture(sampler2D(uEmissiveTexture, uEmissiveSampler), vUV);
 			finalColor.rgb += emissiveColor.rgb * fragmentUniforms.emissivePower;
 		}
-		
+
 		finalColor.a = testAlpha;
 		outColor = finalColor;
 		outColor.a *= fragmentUniforms.alpha * vSumOpacity;
 		out_MouseColorID_Depth = vec4(vMouseColorID, gl_FragCoord.z/gl_FragCoord.w, 0.0, 0.0);
-		
+
 	}
 `;
   static PROGRAM_OPTION_LIST = {

--- a/src/material/system/GridMaterial.js
+++ b/src/material/system/GridMaterial.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseMaterial from "../../base/BaseMaterial.js";
 import ShareGLSL from "../../base/ShareGLSL.js";
 
@@ -34,7 +33,7 @@ export default class GridMaterial extends BaseMaterial {
 	void main() {
 		outColor = vColor;
 			out_MouseColorID_Depth = vec4(0.0);
-		
+
 	}
 	`;
   static PROGRAM_OPTION_LIST = {vertex: [], fragment: []};

--- a/src/material/system/LineMaterial.js
+++ b/src/material/system/LineMaterial.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import TypeSize from "../../resources/TypeSize.js";
 import BaseMaterial from "../../base/BaseMaterial.js";
 import ShareGLSL from "../../base/ShareGLSL.js";
@@ -23,14 +22,14 @@ export default class LineMaterial extends Mix.mix(
 	layout( location = 0 ) in vec3 position;
 	layout( location = 1 ) in vec4 color;
 	layout( location = 0 ) out float vMouseColorID;
-	layout( location = 1 ) out vec4 vColor;		
+	layout( location = 1 ) out vec4 vColor;
 	layout( location = 2 ) out float vSumOpacity;
 	void main() {
 		vMouseColorID = meshUniforms.mouseColorID;
 		vColor = color;
 		vSumOpacity = meshUniforms.sumOpacity;
 		gl_Position = systemUniforms.perspectiveMTX * systemUniforms.cameraMTX * meshMatrixUniforms.modelMatrix[ int(meshUniforms.index) ] * vec4(position,1.0);
-	
+
 	}
 	`;
   static fragmentShaderGLSL = `
@@ -40,15 +39,15 @@ export default class LineMaterial extends Mix.mix(
          float alpha;
     } fragmentUniforms;
 	layout( location = 0 ) in float vMouseColorID;
-	layout( location = 1 ) in vec4 vColor;			
+	layout( location = 1 ) in vec4 vColor;
 	layout( location = 2 ) in float vSumOpacity;
-	layout( location = 0 ) out vec4 outColor;	
+	layout( location = 0 ) out vec4 outColor;
 	layout( location = 1 ) out vec4 out_MouseColorID_Depth;
 	void main() {
 		outColor = vColor;
 		outColor.a *= fragmentUniforms.alpha * vSumOpacity;
 		out_MouseColorID_Depth = vec4(vMouseColorID, gl_FragCoord.z/gl_FragCoord.w, 0.0, 0.0);
-		
+
 	}
 	`;
   static PROGRAM_OPTION_LIST = {vertex: [], fragment: []};

--- a/src/material/system/PBRMaterial_System.js
+++ b/src/material/system/PBRMaterial_System.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import TypeSize from "../../resources/TypeSize.js";
 import BaseMaterial from "../../base/BaseMaterial.js";
 import ShareGLSL from "../../base/ShareGLSL.js";
@@ -31,7 +30,7 @@ export default class PBRMaterial_System extends Mix.mix(
 	${ShareGLSL.GLSL_VERSION}
     ${ShareGLSL.GLSL_SystemUniforms_vertex.systemUniforms}
     ${ShareGLSL.GLSL_SystemUniforms_vertex.meshUniforms}
-         
+
 	layout( location = 0 ) in vec3 position;
 	layout( location = 1 ) in vec3 normal;
 	layout( location = 2 ) in vec2 uv;
@@ -46,7 +45,7 @@ export default class PBRMaterial_System extends Mix.mix(
 	layout( location = 3 ) out vec2 vUV1;
 	layout( location = 4 ) out vec4 vVertexTangent;
 	layout( location = 5 ) out vec4 vVertexPosition;
-	layout( location = 6 ) out float vMouseColorID;	
+	layout( location = 6 ) out float vMouseColorID;
 	layout( location = 7 ) out float vSumOpacity;
 	layout( set = ${ShareGLSL.SET_INDEX_VertexUniforms}, binding = 0 ) uniform VertexUniforms {
 		mat4 jointMatrix[${maxJoint}];
@@ -57,12 +56,12 @@ export default class PBRMaterial_System extends Mix.mix(
         float displacementPower;
         float __displacementTextureRenderYn;
         float useSkin;
-        
+
     } vertexUniforms;
-	
+
 	layout( set = ${ShareGLSL.SET_INDEX_VertexUniforms}, binding = 1 ) uniform sampler uDisplacementSampler;
 	layout( set = ${ShareGLSL.SET_INDEX_VertexUniforms}, binding = 2 ) uniform texture2D uDisplacementTexture;
-	void main() {		
+	void main() {
 		mat4 targetMatrix = meshMatrixUniforms.modelMatrix[ int(meshUniforms.index) ] ;
 		mat4 skinMat = mat4(1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0);
 		if(vertexUniforms.useSkin == TRUTHY) {
@@ -77,16 +76,16 @@ export default class PBRMaterial_System extends Mix.mix(
 			vVertexPosition = meshMatrixUniforms.modelMatrix[ int(meshUniforms.index) ] * vec4(position, 1.0);
 			vNormal = (meshMatrixUniforms.normalMatrix[ int(meshUniforms.index) ] *  vec4(normal,1.0)).xyz;
 		}
-		
+
 		vVertexColor_0 = vertexColor_0;
-		
+
 		vUV = uv;
 		vUV1 = uv1;
 		vVertexTangent = vertexTangent;
 		vMouseColorID = meshUniforms.mouseColorID;
 		vSumOpacity = meshUniforms.sumOpacity;
 		if(vertexUniforms.__displacementTextureRenderYn == TRUTHY) vVertexPosition.xyz += ${ShareGLSL.GLSL_SystemUniforms_vertex.calcDisplacement('vNormal', 'vertexUniforms.displacementFlowSpeedX', 'vertexUniforms.displacementFlowSpeedY', 'vertexUniforms.displacementPower', 'uv', 'uDisplacementTexture', 'uDisplacementSampler')}
-		gl_Position = systemUniforms.perspectiveMTX * systemUniforms.cameraMTX * vVertexPosition;		
+		gl_Position = systemUniforms.perspectiveMTX * systemUniforms.cameraMTX * vVertexPosition;
 	}
 	`;
   static fragmentShaderGLSL = `
@@ -94,10 +93,10 @@ export default class PBRMaterial_System extends Mix.mix(
 	${ShareGLSL.GLSL_SystemUniforms_fragment.systemUniforms}
 	${ShareGLSL.GLSL_SystemUniforms_fragment.cotangent_frame}
 	${ShareGLSL.GLSL_SystemUniforms_fragment.perturb_normal}
-	
+
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 3 ) uniform FragmentUniforms {
         float normalPower;
-        float shininess; 
+        float shininess;
 	    float emissivePower;
 	    float occlusionPower;
 	    float environmentPower;
@@ -124,7 +123,7 @@ export default class PBRMaterial_System extends Mix.mix(
 		float __occlusionTextureRenderYn;
 		float __emissiveTextureRenderYn;
 		float __roughnessTextureRenderYn;
-	    
+
     } fragmentUniforms;
 	layout( location = 0 ) in vec4 vVertexColor_0;
 	layout( location = 1 ) in vec3 vNormal;
@@ -132,22 +131,22 @@ export default class PBRMaterial_System extends Mix.mix(
 	layout( location = 3 ) in vec2 vUV1;
 	layout( location = 4 ) in vec4 vVertexTangent;
 	layout( location = 5 ) in vec4 vVertexPosition;
-	layout( location = 6 ) in float vMouseColorID;	
+	layout( location = 6 ) in float vMouseColorID;
 	layout( location = 7 ) in float vSumOpacity;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 4 ) uniform sampler uDiffuseSampler;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 5 ) uniform texture2D uDiffuseTexture;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 6 ) uniform sampler uNormalSampler;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 7 ) uniform texture2D uNormalTexture;
-	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 8 ) uniform sampler uRoughnessSampler;	
+	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 8 ) uniform sampler uRoughnessSampler;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 9 ) uniform texture2D uRoughnessTexture;
-	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 10 ) uniform sampler uEmissiveSampler;	
+	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 10 ) uniform sampler uEmissiveSampler;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 11 ) uniform texture2D uEmissiveTexture;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 12 ) uniform sampler uEnvironmentSampler;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 13 ) uniform textureCube uEnvironmentTexture;
-	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 14 ) uniform sampler uOcclusionSampler;	
+	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 14 ) uniform sampler uOcclusionSampler;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 15 ) uniform texture2D uOcclusionTexture;
 	layout( location = 0 ) out vec4 outColor;
-	
+
 	layout( location = 1 ) out vec4 out_MouseColorID_Depth;
 	vec2 diffuseTexCoord;
 	vec2 normalTexCoord;
@@ -161,27 +160,27 @@ export default class PBRMaterial_System extends Mix.mix(
 		emissiveTexCoord = fragmentUniforms.emissiveTexCoordIndex == 0.0 ? vUV : vUV1;
 		roughnessTexCoord = fragmentUniforms.roughnessTexCoordIndex == 0.0 ? vUV : vUV1;
 		occlusionTexCoord = fragmentUniforms.occlusionTexCoordIndex == 0.0 ? vUV : vUV1;
-		
-		
+
+
 		float tMetallicPower = fragmentUniforms.metallicFactor;
 		float tRoughnessPower = fragmentUniforms.roughnessFactor;
-		
+
 		vec4 roughnessColor = vec4(0.0);
 		if(fragmentUniforms.__roughnessTextureRenderYn == TRUTHY) {
 			roughnessColor = texture(sampler2D(uRoughnessTexture, uRoughnessSampler), roughnessTexCoord);
 			tMetallicPower *= roughnessColor.b; // 메탈릭 산출 roughnessColor.b
 			tRoughnessPower *= roughnessColor.g; // 거칠기 산출 roughnessColor.g
 		}
-		
-		
-	
+
+
+
 		vec4 diffuseColor = fragmentUniforms.baseColorFactor;
 		if(fragmentUniforms.useVertexColor_0 == TRUTHY) diffuseColor *= clamp(vVertexColor_0,0.0,1.0) ;
 		if(fragmentUniforms.__diffuseTextureRenderYn == TRUTHY) diffuseColor *= texture(sampler2D(uDiffuseTexture, uDiffuseSampler), diffuseTexCoord) ;
-			
+
 		float tAlpha = diffuseColor.a;
-	
-		
+
+
 	    vec3 N = normalize(vNormal);
 	    bool backFaceYn = false;
 	    if(fragmentUniforms.useMaterialDoubleSide == TRUTHY) {
@@ -189,7 +188,7 @@ export default class PBRMaterial_System extends Mix.mix(
 			vec3 fdy = dFdy(vVertexPosition.xyz);
 			vec3 faceNormal = normalize(cross(fdy,fdx));
 			if (dot (vNormal, faceNormal) < 0.0) { N = -N; backFaceYn = true; };
-	    } 
+	    }
 		vec4 normalColor = vec4(0.0);
 		if(fragmentUniforms.__normalTextureRenderYn == TRUTHY) normalColor = texture(sampler2D(uNormalTexture, uNormalSampler), normalTexCoord) ;
 		if(fragmentUniforms.useFlatMode == TRUTHY) N = getFlatNormal(vVertexPosition.xyz);
@@ -208,27 +207,27 @@ export default class PBRMaterial_System extends Mix.mix(
 				mat3 tbn = mat3(t, b, ng);
 				N = normalize(tbn * ((2.0 * normalColor.rgb - 1.0) * vec3(1.0, 1.0 * vVertexTangent.w,1.0)));
 				N = backFaceYn ? -N : N;
-			}			
+			}
 		}
 
 		if(fragmentUniforms.__environmentTextureRenderYn == TRUTHY) {
 			// 환경맵 계산
 			vec3 R = reflect( vVertexPosition.xyz - systemUniforms.cameraPosition, N);
-			vec4 reflectionColor = texture(samplerCube(uEnvironmentTexture,uEnvironmentSampler), R);		
+			vec4 reflectionColor = texture(samplerCube(uEnvironmentTexture,uEnvironmentSampler), R);
 			// 환경맵 합성
 			diffuseColor.rgb = mix( diffuseColor.rgb , reflectionColor.rgb , max(tMetallicPower-tRoughnessPower,0.0)*(1.0-tRoughnessPower));
 			diffuseColor = mix( diffuseColor , vec4(0.04, 0.04, 0.04, 1.0) , tRoughnessPower * (tMetallicPower) * 0.5);
 		}
-		
 
 
-	
+
+
 		outColor = diffuseColor;
 		vec4 specularLightColor = vec4(1.0, 1.0, 1.0, 1.0);
 	    vec4 ld = vec4(0.0, 0.0, 0.0, 1.0);
 	    vec4 ls = vec4(0.0, 0.0, 0.0, 1.0);
 
-	    vec3 L;	
+	    vec3 L;
 
 
 	    float lambertTerm;
@@ -248,15 +247,15 @@ export default class PBRMaterial_System extends Mix.mix(
 				ls +=  specularLightColor * specular * fragmentUniforms.metallicFactor * lightInfo.intensity * lightInfo.color.a * (1.0-tRoughnessPower+0.04);
 			}
 		}
-		
+
 		 vec4 finalColor = ld + ls + la;;
-		
+
 		if(fragmentUniforms.__emissiveTextureRenderYn == TRUTHY) {
 			// 이미시브 합성
 			vec4 emissiveColor = texture(sampler2D(uEmissiveTexture, uEmissiveSampler), emissiveTexCoord);
 			finalColor.rgb += emissiveColor.rgb * fragmentUniforms.emissivePower;
-		}		
-	
+		}
+
 		if(fragmentUniforms.__occlusionTextureRenderYn == TRUTHY) {
 		// 오클루젼 합성
 			vec4 occlusionColor =texture(sampler2D(uOcclusionTexture, uOcclusionSampler), occlusionTexCoord);
@@ -265,7 +264,7 @@ export default class PBRMaterial_System extends Mix.mix(
 
 
 		// 알파블렌드 - BLEND
-		if( fragmentUniforms.alphaBlend == 2.0 ) {		
+		if( fragmentUniforms.alphaBlend == 2.0 ) {
 			finalColor.a = tAlpha;
 		}
     if(fragmentUniforms.useCutOff == TRUTHY) {
@@ -273,7 +272,7 @@ export default class PBRMaterial_System extends Mix.mix(
 		}
 		outColor = finalColor;
 		out_MouseColorID_Depth = vec4(vMouseColorID, gl_FragCoord.z/gl_FragCoord.w, 0.0, 0.0);
-		
+
 	}
 `;
   static PROGRAM_OPTION_LIST = {

--- a/src/material/system/SkyBoxMaterial.js
+++ b/src/material/system/SkyBoxMaterial.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseMaterial from "../../base/BaseMaterial.js";
 import ShareGLSL from "../../base/ShareGLSL.js";
 import Mix from "../../base/Mix.js";

--- a/src/material/system/TextMaterial.js
+++ b/src/material/system/TextMaterial.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseMaterial from "../../base/BaseMaterial.js";
 import ShareGLSL from "../../base/ShareGLSL.js";
 import Mix from "../../base/Mix.js";
@@ -32,28 +31,28 @@ export default class TextMaterial extends Mix.mix(
 	layout( location = 2 ) in vec2 uv;
 	layout( location = 0 ) out vec3 vNormal;
 	layout( location = 1 ) out vec2 vUV;
-	layout( location = 2 ) out float vMouseColorID;	
+	layout( location = 2 ) out float vMouseColorID;
 	layout( location = 3 ) out float vSumOpacity;
-    ${ShareGLSL.GLSL_SystemUniforms_vertex.getSprite3DMatrix}	
+    ${ShareGLSL.GLSL_SystemUniforms_vertex.getSprite3DMatrix}
 	void main() {
 		float w = vertexUniforms.width ;
 		float h = vertexUniforms.height ;
 		mat4 modelMatrix = meshMatrixUniforms.modelMatrix[ int(meshUniforms.index) ];
 		mat4 targetMatrix;
-		
+
 		// 기본
 		targetMatrix = modelMatrix * mat4( w / max( w, h ), 0.0, 0.0, 0.0,   0.0, h / max( w, h ), 0.0, 0.0,    0.0, 0.0, 1.0, 0.0,    0.0, 0.0, 0.0, 1.0 );
-		gl_Position = systemUniforms.perspectiveMTX * systemUniforms.cameraMTX * targetMatrix * vec4(position,1.0);				
-		
+		gl_Position = systemUniforms.perspectiveMTX * systemUniforms.cameraMTX * targetMatrix * vec4(position,1.0);
+
 		// sprite3D
 		//#RedGPU#useSprite3DMode#  targetMatrix = modelMatrix * mat4( w / systemUniforms.resolution.y, 0.0, 0.0, 0.0,    0.0, h / systemUniforms.resolution.y, 0.0, 0.0,    0.0, 0.0, 1.0, 0.0,    0.0, 0.0, 0.0, 1.0);
-		//#RedGPU#useSprite3DMode#  gl_Position = systemUniforms.perspectiveMTX * getSprite3DMatrix( systemUniforms.cameraMTX, targetMatrix ) * vec4(position,1.0);	
-			
-		
+		//#RedGPU#useSprite3DMode#  gl_Position = systemUniforms.perspectiveMTX * getSprite3DMatrix( systemUniforms.cameraMTX, targetMatrix ) * vec4(position,1.0);
+
+
 		//#RedGPU#useSprite3DMode#  //#RedGPU#useFixedScale#  gl_Position /= gl_Position.w;
 		//#RedGPU#useSprite3DMode#  //#RedGPU#useFixedScale#  gl_Position.xy += position.xy * vec2((systemUniforms.perspectiveMTX * targetMatrix)[0][0],(systemUniforms.perspectiveMTX * targetMatrix)[1][1]);
-	
-		
+
+
 		vNormal = normal;
 		vUV = uv;
 		vMouseColorID = meshUniforms.mouseColorID;
@@ -64,7 +63,7 @@ export default class TextMaterial extends Mix.mix(
 	${ShareGLSL.GLSL_VERSION}
 	layout( location = 0 ) in vec3 vNormal;
 	layout( location = 1 ) in vec2 vUV;
-	layout( location = 2 ) in float vMouseColorID;	
+	layout( location = 2 ) in float vMouseColorID;
 	layout( location = 3 ) in float vSumOpacity;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 1 ) uniform FragmentUniforms {
         float alpha;
@@ -72,7 +71,7 @@ export default class TextMaterial extends Mix.mix(
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 2 ) uniform sampler uSampler;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 3 ) uniform texture2D uDiffuseTexture;
 	layout( location = 0 ) out vec4 outColor;
-	
+
 	layout( location = 1 ) out vec4 out_MouseColorID_Depth;
 	void main() {
 		vec4 diffuseColor = vec4(0.0);
@@ -81,7 +80,7 @@ export default class TextMaterial extends Mix.mix(
 		outColor = diffuseColor;
 		outColor.a *= fragmentUniforms.alpha * vSumOpacity;
 		out_MouseColorID_Depth = vec4(vMouseColorID, gl_FragCoord.z/gl_FragCoord.w, 0.0, 0.0);
-		
+
 	}
 `;
   static PROGRAM_OPTION_LIST = {

--- a/src/object3D/Axis.js
+++ b/src/object3D/Axis.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseObject3D from "../base/BaseObject3D.js";
 import Box from "../primitives/Box.js";
 import Cylinder from "../primitives/Cylinder.js";

--- a/src/object3D/Grid.js
+++ b/src/object3D/Grid.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseObject3D from "../base/BaseObject3D.js";
 import UTIL from "../util/UTIL.js";
 import Geometry from "../geometry/Geometry.js";

--- a/src/object3D/Mesh.js
+++ b/src/object3D/Mesh.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseObject3D from "../base/BaseObject3D.js";
 
 export default class Mesh extends BaseObject3D {

--- a/src/object3D/SkyBox.js
+++ b/src/object3D/SkyBox.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.1.1 18:50:31
  *
  */
-"use strict";
 import BaseObject3D from "../base/BaseObject3D.js";
 import Box from "../primitives/Box.js";
 import SkyBoxMaterial from "../material/system/SkyBoxMaterial.js";

--- a/src/object3D/Sprite3D.js
+++ b/src/object3D/Sprite3D.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.1.8 18:27:58
  *
  */
-"use strict";
 import BaseObject3D from "../base/BaseObject3D.js";
 import Sprite3DMaterial from "../material/Sprite3DMaterial.js";
 import UTIL from "../util/UTIL.js";

--- a/src/object3D/Text.js
+++ b/src/object3D/Text.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseObject3D from "../base/BaseObject3D.js";
 import UTIL from "../util/UTIL.js";
 import Plane from "../primitives/Plane.js";

--- a/src/particle/ParticleMaterial.js
+++ b/src/particle/ParticleMaterial.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import ShareGLSL from "../base/ShareGLSL.js";
 import TypeSize from "../resources/TypeSize.js";
 import BitmapMaterial from "../material/BitmapMaterial.js";
@@ -17,7 +16,7 @@ export default class ParticleMaterial extends BitmapMaterial {
 	${ShareGLSL.GLSL_VERSION}
 	${ShareGLSL.GLSL_SystemUniforms_vertex.systemUniforms}
     ${ShareGLSL.GLSL_SystemUniforms_vertex.meshUniforms}
-    ${ShareGLSL.GLSL_SystemUniforms_vertex.getSprite3DMatrix}    
+    ${ShareGLSL.GLSL_SystemUniforms_vertex.getSprite3DMatrix}
 	layout(location = 0) in vec3 a_pos;
     layout(location = 1) in vec2 a_uv;
     layout(location = 2) in vec3 position;
@@ -25,7 +24,7 @@ export default class ParticleMaterial extends BitmapMaterial {
     layout(location = 4) in vec3 rotation;
     layout(location = 5) in float scale;
 	layout(location = 0 ) out vec2 vUV;
-	layout(location = 1 ) out float vMouseColorID;	
+	layout(location = 1 ) out float vMouseColorID;
 	layout(location = 2 ) out float vSumOpacity;
 	layout( set = ${ShareGLSL.SET_INDEX_VertexUniforms}, binding = 0 ) uniform VertexUniforms {
         float sprite3DMode;
@@ -42,7 +41,7 @@ export default class ParticleMaterial extends BitmapMaterial {
 		vUV = a_uv;
 		vMouseColorID = meshUniforms.mouseColorID;
 		vSumOpacity = meshUniforms.sumOpacity * alpha;
-		float ratio = systemUniforms.resolution.x/systemUniforms.resolution.y; 
+		float ratio = systemUniforms.resolution.x/systemUniforms.resolution.y;
 		if( vertexUniforms.sprite3DMode == 1.0 ) {
 			mat4 scaleMTX = mat4(
 				1, 0, 0, 0,
@@ -67,14 +66,14 @@ export default class ParticleMaterial extends BitmapMaterial {
 			* rotationMTX(rotation);
 			gl_Position = systemUniforms.perspectiveMTX *  systemUniforms.cameraMTX * scaleMTX * vec4(a_pos , 1);
 		}
-		
+
 	}
 	`;
   static fragmentShaderGLSL = `
 	${ShareGLSL.GLSL_VERSION}
 	const float TRUTHY = 1.0;
 	layout( location = 0 ) in vec2 vUV;
-	layout( location = 1 ) in float vMouseColorID;	
+	layout( location = 1 ) in float vMouseColorID;
 	layout( location = 2 ) in float vSumOpacity;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 1 ) uniform FragmentUniforms {
         float alpha;
@@ -91,7 +90,7 @@ export default class ParticleMaterial extends BitmapMaterial {
 		outColor = diffuseColor;
 		outColor.a *= fragmentUniforms.alpha * vSumOpacity;
 		out_MouseColorID_Depth = vec4(vMouseColorID, gl_FragCoord.z/gl_FragCoord.w, 0.0, 0.0);
-		
+
 	}
 `;
   static PROGRAM_OPTION_LIST = {

--- a/src/postEffect/PostEffect.js
+++ b/src/postEffect/PostEffect.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.1.11 18:20:56
  *
  */
-"use strict";
 
 import UTIL from "../util/UTIL.js";
 

--- a/src/postEffect/PostEffect_Convolution.js
+++ b/src/postEffect/PostEffect_Convolution.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseMaterial from "../base/BaseMaterial.js";
 import ShareGLSL from "../base/ShareGLSL.js";
 import BasePostEffect from "../base/BasePostEffect.js";
@@ -17,7 +16,7 @@ export default class PostEffect_Convolution extends BasePostEffect {
   static vertexShaderGLSL = `
 	${ShareGLSL.GLSL_VERSION}
 	${ShareGLSL.GLSL_SystemUniforms_vertex.systemUniforms}
-    
+
 	layout( location = 0 ) in vec3 position;
 	layout( location = 1 ) in vec3 normal;
 	layout( location = 2 ) in vec2 uv;
@@ -44,7 +43,7 @@ export default class PostEffect_Convolution extends BasePostEffect {
 	layout( set = ${ShareGLSL.SET_INDEX_VertexUniforms}, binding = 1 ) uniform sampler uSampler;
 	layout( set = ${ShareGLSL.SET_INDEX_VertexUniforms}, binding = 2 ) uniform texture2D uSourceTexture;
 	layout( location = 0 ) out vec4 outColor;
-	
+
 	void main() {
 
 		vec2 perPX = vec2(1.0/systemUniforms.resolution.x, 1.0/systemUniforms.resolution.y);
@@ -58,7 +57,7 @@ export default class PostEffect_Convolution extends BasePostEffect {
 		finalColor += texture( sampler2D( uSourceTexture, uSampler ), vUV + perPX * vec2(-1.0,  1.0)) * fragmentUniforms.kernel[2][0] ;
 		finalColor += texture( sampler2D( uSourceTexture, uSampler ), vUV + perPX * vec2( 0.0,  1.0)) * fragmentUniforms.kernel[2][1] ;
 		finalColor += texture( sampler2D( uSourceTexture, uSampler ), vUV + perPX * vec2( 1.0,  1.0)) * fragmentUniforms.kernel[2][2] ;
-	
+
 		outColor = vec4((finalColor / fragmentUniforms.kernelWeight).rgb, 1.0);
 	}
 `;

--- a/src/postEffect/PostEffect_Film.js
+++ b/src/postEffect/PostEffect_Film.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseMaterial from "../base/BaseMaterial.js";
 import ShareGLSL from "../base/ShareGLSL.js";
 import BasePostEffect from "../base/BasePostEffect.js";
@@ -17,7 +16,7 @@ export default class PostEffect_Film extends BasePostEffect {
   static vertexShaderGLSL = `
 	${ShareGLSL.GLSL_VERSION}
 	${ShareGLSL.GLSL_SystemUniforms_vertex.systemUniforms}
-    
+
 	layout( location = 0 ) in vec3 position;
 	layout( location = 1 ) in vec3 normal;
 	layout( location = 2 ) in vec2 uv;
@@ -46,7 +45,7 @@ export default class PostEffect_Film extends BasePostEffect {
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 1 ) uniform sampler uSampler;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 2 ) uniform texture2D uSourceTexture;
 	layout( location = 0 ) out vec4 outColor;
-	
+
 	float random(vec3 scale, float seed) {
 		return fract(sin(dot(gl_FragCoord.xyz + seed, scale)) * 43758.5453 + seed);
 	}
@@ -59,19 +58,19 @@ export default class PostEffect_Film extends BasePostEffect {
 		float x = vUV.x * vUV.y * vTime;
 		x = mod( x, 13.0 ) * mod( x, 123.0 );
 		float dx = mod( x, 0.01 );
-		
+
 		// add noise
 		vec3 finalColor = diffuseColor.rgb + diffuseColor.rgb * clamp( 0.1 + dx * 100.0, 0.0, 1.0 );
-		
+
 		// get us a sine and cosine
 		vec2 sc = vec2( sin( vUV.y * fragmentUniforms.scanlineCount ), cos( vUV.y * fragmentUniforms.scanlineCount ) );
-		
+
 		// add scanlines
 		finalColor += diffuseColor.rgb * vec3( sc.x, sc.y, sc.x ) * fragmentUniforms.scanlineIntensity;
-		
+
 		// interpolate between source and result by intensity
 		finalColor = diffuseColor.rgb + clamp( fragmentUniforms.noiseIntensity, 0.0, 1.0 ) * ( finalColor - diffuseColor.rgb );
-		
+
 		// convert to grayscale if desired
 		if(fragmentUniforms.grayMode == 1.0) finalColor = vec3( finalColor.r * 0.3 + finalColor.g * 0.59 + finalColor.b * 0.11 );
 		outColor = vec4( finalColor, diffuseColor.a );

--- a/src/postEffect/PostEffect_Vignetting.js
+++ b/src/postEffect/PostEffect_Vignetting.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseMaterial from "../base/BaseMaterial.js";
 import ShareGLSL from "../base/ShareGLSL.js";
 import BasePostEffect from "../base/BasePostEffect.js";
@@ -17,7 +16,7 @@ export default class PostEffect_Vignetting extends BasePostEffect {
   static vertexShaderGLSL = `
 	${ShareGLSL.GLSL_VERSION}
 	${ShareGLSL.GLSL_SystemUniforms_vertex.systemUniforms}
-    
+
 	layout( location = 0 ) in vec3 position;
 	layout( location = 1 ) in vec3 normal;
 	layout( location = 2 ) in vec2 uv;

--- a/src/postEffect/adjustments/PostEffect_BrightnessContrast.js
+++ b/src/postEffect/adjustments/PostEffect_BrightnessContrast.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseMaterial from "../../base/BaseMaterial.js";
 import ShareGLSL from "../../base/ShareGLSL.js";
 import BasePostEffect from "../../base/BasePostEffect.js";
@@ -17,7 +16,7 @@ export default class PostEffect_BrightnessContrast extends BasePostEffect {
   static vertexShaderGLSL = `
 	${ShareGLSL.GLSL_VERSION}
 	${ShareGLSL.GLSL_SystemUniforms_vertex.systemUniforms}
-    
+
 	layout( location = 0 ) in vec3 position;
 	layout( location = 1 ) in vec3 normal;
 	layout( location = 2 ) in vec2 uv;

--- a/src/postEffect/adjustments/PostEffect_Gray.js
+++ b/src/postEffect/adjustments/PostEffect_Gray.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseMaterial from "../../base/BaseMaterial.js";
 import ShareGLSL from "../../base/ShareGLSL.js";
 import BasePostEffect from "../../base/BasePostEffect.js";
@@ -15,7 +14,7 @@ export default class PostEffect_Gray extends BasePostEffect {
   static vertexShaderGLSL = `
 	${ShareGLSL.GLSL_VERSION}
 	${ShareGLSL.GLSL_SystemUniforms_vertex.systemUniforms}
-    
+
 	layout( location = 0 ) in vec3 position;
 	layout( location = 1 ) in vec3 normal;
 	layout( location = 2 ) in vec2 uv;

--- a/src/postEffect/adjustments/PostEffect_HueSaturation.js
+++ b/src/postEffect/adjustments/PostEffect_HueSaturation.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseMaterial from "../../base/BaseMaterial.js";
 import ShareGLSL from "../../base/ShareGLSL.js";
 import BasePostEffect from "../../base/BasePostEffect.js";
@@ -17,7 +16,7 @@ export default class PostEffect_HueSaturation extends BasePostEffect {
   static vertexShaderGLSL = `
 	${ShareGLSL.GLSL_VERSION}
 	${ShareGLSL.GLSL_SystemUniforms_vertex.systemUniforms}
-    
+
 	layout( location = 0 ) in vec3 position;
 	layout( location = 1 ) in vec3 normal;
 	layout( location = 2 ) in vec2 uv;
@@ -43,24 +42,24 @@ export default class PostEffect_HueSaturation extends BasePostEffect {
 	void main() {
 		vec4 finalColor = vec4(0.0);
 		finalColor = texture( sampler2D( uSourceTexture, uSampler ), vUV );
-		
+
 		float hue_value = fragmentUniforms.hue;
 		float angle = hue_value * 3.1415926535897932384626433832795;
 		float s = sin(angle), c = cos(angle);
 		vec3 weights = (vec3(2.0 * c, -sqrt(3.0) * s - c, sqrt(3.0) * s - c) + 1.0) / 3.0;
 		float len = length(finalColor.rgb);
-		
+
 		finalColor.rgb = vec3(
 			dot(finalColor.rgb, weights.xyz),
 			dot(finalColor.rgb, weights.zxy),
 			dot(finalColor.rgb, weights.yzx)
 		);
-		
+
 		float average = (finalColor.r + finalColor.g + finalColor.b) / 3.0;
 		float saturation_value = fragmentUniforms.saturation;
 		if (saturation_value > 0.0) finalColor.rgb += (average - finalColor.rgb) * (1.0 - 1.0 / (1.001 - saturation_value));
 		else finalColor.rgb += (average - finalColor.rgb) * (-saturation_value);
-		
+
 		outColor = finalColor;
 	}
 `;

--- a/src/postEffect/adjustments/PostEffect_Invert.js
+++ b/src/postEffect/adjustments/PostEffect_Invert.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseMaterial from "../../base/BaseMaterial.js";
 import ShareGLSL from "../../base/ShareGLSL.js";
 import BasePostEffect from "../../base/BasePostEffect.js";
@@ -15,7 +14,7 @@ export default class PostEffect_Invert extends BasePostEffect {
   static vertexShaderGLSL = `
 	${ShareGLSL.GLSL_VERSION}
 	${ShareGLSL.GLSL_SystemUniforms_vertex.systemUniforms}
-    
+
 	layout( location = 0 ) in vec3 position;
 	layout( location = 1 ) in vec3 normal;
 	layout( location = 2 ) in vec2 uv;

--- a/src/postEffect/adjustments/PostEffect_Threshold.js
+++ b/src/postEffect/adjustments/PostEffect_Threshold.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseMaterial from "../../base/BaseMaterial.js";
 import ShareGLSL from "../../base/ShareGLSL.js";
 import BasePostEffect from "../../base/BasePostEffect.js";
@@ -17,7 +16,7 @@ export default class PostEffect_Threshold extends BasePostEffect {
   static vertexShaderGLSL = `
 	${ShareGLSL.GLSL_VERSION}
 	${ShareGLSL.GLSL_SystemUniforms_vertex.systemUniforms}
-    
+
 	layout( location = 0 ) in vec3 position;
 	layout( location = 1 ) in vec3 normal;
 	layout( location = 2 ) in vec2 uv;

--- a/src/postEffect/bloom/PostEffect_Bloom.js
+++ b/src/postEffect/bloom/PostEffect_Bloom.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseMaterial from "../../base/BaseMaterial.js";
 import BasePostEffect from "../../base/BasePostEffect.js";
 import PostEffect_GaussianBlur from "../blur/PostEffect_GaussianBlur.js";

--- a/src/postEffect/bloom/PostEffect_Bloom.js
+++ b/src/postEffect/bloom/PostEffect_Bloom.js
@@ -11,7 +11,6 @@ import BasePostEffect from "../../base/BasePostEffect.js";
 import PostEffect_GaussianBlur from "../blur/PostEffect_GaussianBlur.js";
 import PostEffect_Threshold from "../adjustments/PostEffect_Threshold.js";
 import PostEffect_Bloom_blend from "./PostEffect_Bloom_blend.js";
-import ShareGLSL from "../../base/ShareGLSL.js";
 
 export default class PostEffect_Bloom extends BasePostEffect {
 

--- a/src/postEffect/bloom/PostEffect_Bloom_blend.js
+++ b/src/postEffect/bloom/PostEffect_Bloom_blend.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseMaterial from "../../base/BaseMaterial.js";
 import ShareGLSL from "../../base/ShareGLSL.js";
 import BasePostEffect from "../../base/BasePostEffect.js";
@@ -17,7 +16,7 @@ export default class PostEffect_Bloom_blend extends BasePostEffect {
   static vertexShaderGLSL = `
 	${ShareGLSL.GLSL_VERSION}
 	${ShareGLSL.GLSL_SystemUniforms_vertex.systemUniforms}
-    
+
 	layout( location = 0 ) in vec3 position;
 	layout( location = 1 ) in vec3 normal;
 	layout( location = 2 ) in vec2 uv;
@@ -47,7 +46,7 @@ export default class PostEffect_Bloom_blend extends BasePostEffect {
 		vec4 blurColor;
 		vec4 finalColor;
 		diffuseColor = texture( sampler2D( uSourceTexture, uSampler ), vUV );
-		blurColor = texture( sampler2D( uBlurTexture, uSampler ), vUV );	
+		blurColor = texture( sampler2D( uBlurTexture, uSampler ), vUV );
 		finalColor = diffuseColor;
 		finalColor.rgb = (finalColor.rgb  + blurColor.rgb * fragmentUniforms.bloomStrength ) * fragmentUniforms.exposure ;
 		outColor = finalColor;

--- a/src/postEffect/blur/PostEffect_Blur.js
+++ b/src/postEffect/blur/PostEffect_Blur.js
@@ -6,7 +6,6 @@
   *
   */
 
-"use strict";
 import BaseMaterial from "../../base/BaseMaterial.js";
 import ShareGLSL from "../../base/ShareGLSL.js";
 import BasePostEffect from "../../base/BasePostEffect.js";
@@ -15,7 +14,7 @@ export default class PostEffect_Blur extends BasePostEffect {
   static vertexShaderGLSL = `
 	${ShareGLSL.GLSL_VERSION}
 	${ShareGLSL.GLSL_SystemUniforms_vertex.systemUniforms}
-    
+
 	layout( location = 0 ) in vec3 position;
 	layout( location = 1 ) in vec3 normal;
 	layout( location = 2 ) in vec2 uv;

--- a/src/postEffect/blur/PostEffect_BlurX.js
+++ b/src/postEffect/blur/PostEffect_BlurX.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseMaterial from "../../base/BaseMaterial.js";
 import ShareGLSL from "../../base/ShareGLSL.js";
 import BasePostEffect from "../../base/BasePostEffect.js";
@@ -17,7 +16,7 @@ export default class PostEffect_BlurX extends BasePostEffect {
   static vertexShaderGLSL = `
 	${ShareGLSL.GLSL_VERSION}
 	${ShareGLSL.GLSL_SystemUniforms_vertex.systemUniforms}
-    
+
 	layout( location = 0 ) in vec3 position;
 	layout( location = 1 ) in vec3 normal;
 	layout( location = 2 ) in vec2 uv;
@@ -40,7 +39,7 @@ export default class PostEffect_BlurX extends BasePostEffect {
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 1 ) uniform sampler uSampler;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 2 ) uniform texture2D uSourceTexture;
 	layout( location = 0 ) out vec4 outColor;
-	
+
 	float random(vec3 scale, float seed) {
 		return fract(sin(dot(gl_FragCoord.xyz + seed, scale)) * 43758.5453 + seed);
 	}

--- a/src/postEffect/blur/PostEffect_BlurY.js
+++ b/src/postEffect/blur/PostEffect_BlurY.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseMaterial from "../../base/BaseMaterial.js";
 import ShareGLSL from "../../base/ShareGLSL.js";
 import BasePostEffect from "../../base/BasePostEffect.js";
@@ -17,7 +16,7 @@ export default class PostEffect_BlurY extends BasePostEffect {
   static vertexShaderGLSL = `
 	${ShareGLSL.GLSL_VERSION}
 	${ShareGLSL.GLSL_SystemUniforms_vertex.systemUniforms}
-    
+
 	layout( location = 0 ) in vec3 position;
 	layout( location = 1 ) in vec3 normal;
 	layout( location = 2 ) in vec2 uv;
@@ -40,7 +39,7 @@ export default class PostEffect_BlurY extends BasePostEffect {
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 1 ) uniform sampler uSampler;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 2 ) uniform texture2D uSourceTexture;
 	layout( location = 0 ) out vec4 outColor;
-	
+
 	float random(vec3 scale, float seed) {
 		return fract(sin(dot(gl_FragCoord.xyz + seed, scale)) * 43758.5453 + seed);
 	}

--- a/src/postEffect/blur/PostEffect_GaussianBlur.js
+++ b/src/postEffect/blur/PostEffect_GaussianBlur.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseMaterial from "../../base/BaseMaterial.js";
 import BasePostEffect from "../../base/BasePostEffect.js";
 import PostEffect_BlurX from "./PostEffect_BlurX.js";

--- a/src/postEffect/blur/PostEffect_GaussianBlur.js
+++ b/src/postEffect/blur/PostEffect_GaussianBlur.js
@@ -10,7 +10,6 @@ import BaseMaterial from "../../base/BaseMaterial.js";
 import BasePostEffect from "../../base/BasePostEffect.js";
 import PostEffect_BlurX from "./PostEffect_BlurX.js";
 import PostEffect_BlurY from "./PostEffect_BlurY.js";
-import ShareGLSL from "../../base/ShareGLSL.js";
 
 export default class PostEffect_GaussianBlur extends BasePostEffect {
 

--- a/src/postEffect/blur/PostEffect_ZoomBlur.js
+++ b/src/postEffect/blur/PostEffect_ZoomBlur.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseMaterial from "../../base/BaseMaterial.js";
 import ShareGLSL from "../../base/ShareGLSL.js";
 import BasePostEffect from "../../base/BasePostEffect.js";
@@ -17,7 +16,7 @@ export default class PostEffect_ZoomBlur extends BasePostEffect {
   static vertexShaderGLSL = `
 	${ShareGLSL.GLSL_VERSION}
 	${ShareGLSL.GLSL_SystemUniforms_vertex.systemUniforms}
-    
+
 	layout( location = 0 ) in vec3 position;
 	layout( location = 1 ) in vec3 normal;
 	layout( location = 2 ) in vec2 uv;
@@ -42,7 +41,7 @@ export default class PostEffect_ZoomBlur extends BasePostEffect {
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 1 ) uniform sampler uSampler;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 2 ) uniform texture2D uSourceTexture;
 	layout( location = 0 ) out vec4 outColor;
-	
+
 	float random(vec3 scale, float seed) {
 		return fract(sin(dot(gl_FragCoord.xyz + seed, scale)) * 43758.5453 + seed);
 	}
@@ -53,7 +52,7 @@ export default class PostEffect_ZoomBlur extends BasePostEffect {
 		vec2 toCenter = center - vUV ;
 		float offset = random(vec3(12.9898, 78.233, 151.7182), 0.0);
 		float total = 0.0;
-		
+
 		for (float t = 0.0; t <= 30.0; t++) {
 			float percent = (t + offset) / 30.0;
 			float weight = 3.0 * (percent - percent * percent);

--- a/src/postEffect/dof/PostEffect_DoF.js
+++ b/src/postEffect/dof/PostEffect_DoF.js
@@ -10,7 +10,6 @@ import BaseMaterial from "../../base/BaseMaterial.js";
 import BasePostEffect from "../../base/BasePostEffect.js";
 import PostEffect_GaussianBlur from "../blur/PostEffect_GaussianBlur.js";
 import PostEffect_DoF_blend from "./PostEffect_DoF_blend.js";
-import ShareGLSL from "../../base/ShareGLSL.js";
 
 export default class PostEffect_DoF extends BasePostEffect {
 

--- a/src/postEffect/dof/PostEffect_DoF.js
+++ b/src/postEffect/dof/PostEffect_DoF.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseMaterial from "../../base/BaseMaterial.js";
 import BasePostEffect from "../../base/BasePostEffect.js";
 import PostEffect_GaussianBlur from "../blur/PostEffect_GaussianBlur.js";

--- a/src/postEffect/dof/PostEffect_DoF_blend.js
+++ b/src/postEffect/dof/PostEffect_DoF_blend.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseMaterial from "../../base/BaseMaterial.js";
 import ShareGLSL from "../../base/ShareGLSL.js";
 import BasePostEffect from "../../base/BasePostEffect.js";
@@ -17,7 +16,7 @@ export default class PostEffect_DoF_blend extends BasePostEffect {
   static vertexShaderGLSL = `
 	${ShareGLSL.GLSL_VERSION}
 	${ShareGLSL.GLSL_SystemUniforms_vertex.systemUniforms}
-    
+
 	layout( location = 0 ) in vec3 position;
 	layout( location = 1 ) in vec3 normal;
 	layout( location = 2 ) in vec2 uv;
@@ -50,7 +49,7 @@ export default class PostEffect_DoF_blend extends BasePostEffect {
 		blurColor = texture( sampler2D( uBlurTexture, uSampler ), vUV );
 		depthColor = texture( sampler2D( uDepthTexture, uSampler ), vUV );
 		depthColor = depthColor * fragmentUniforms.focusLength;
-		
+
 		diffuseColor.rgb *= min(depthColor.g,1.0);
 		blurColor.rgb *= max(1.0 - depthColor.g,0.0);
 		outColor = diffuseColor + blurColor;

--- a/src/postEffect/pixelate/PostEffect_HalfTone.js
+++ b/src/postEffect/pixelate/PostEffect_HalfTone.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseMaterial from "../../base/BaseMaterial.js";
 import ShareGLSL from "../../base/ShareGLSL.js";
 import BasePostEffect from "../../base/BasePostEffect.js";
@@ -17,7 +16,7 @@ export default class PostEffect_HalfTone extends BasePostEffect {
   static vertexShaderGLSL = `
 	${ShareGLSL.GLSL_VERSION}
 	${ShareGLSL.GLSL_SystemUniforms_vertex.systemUniforms}
-    
+
 	layout( location = 0 ) in vec3 position;
 	layout( location = 1 ) in vec3 normal;
 	layout( location = 2 ) in vec2 uv;
@@ -44,7 +43,7 @@ export default class PostEffect_HalfTone extends BasePostEffect {
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 1 ) uniform sampler uSampler;
 	layout( set = ${ShareGLSL.SET_INDEX_FragmentUniforms}, binding = 2 ) uniform texture2D uSourceTexture;
 	layout( location = 0 ) out vec4 outColor;
-	
+
 	float pattern(float angle) {
 		angle = angle * 3.141592653589793/180.0;
 		float s = sin(angle), c = cos(angle);

--- a/src/postEffect/pixelate/PostEffect_Pixelize.js
+++ b/src/postEffect/pixelate/PostEffect_Pixelize.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseMaterial from "../../base/BaseMaterial.js";
 import ShareGLSL from "../../base/ShareGLSL.js";
 import BasePostEffect from "../../base/BasePostEffect.js";
@@ -17,7 +16,7 @@ export default class PostEffect_Pixelize extends BasePostEffect {
   static vertexShaderGLSL = `
 	${ShareGLSL.GLSL_VERSION}
 	${ShareGLSL.GLSL_SystemUniforms_vertex.systemUniforms}
-    
+
 	layout( location = 0 ) in vec3 position;
 	layout( location = 1 ) in vec3 normal;
 	layout( location = 2 ) in vec2 uv;

--- a/src/primitives/Box.js
+++ b/src/primitives/Box.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import Buffer from "../buffer/Buffer.js";
 import Geometry from "../geometry/Geometry.js";
 import InterleaveInfo from "../geometry/InterleaveInfo.js";

--- a/src/primitives/Cylinder.js
+++ b/src/primitives/Cylinder.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import Buffer from "../buffer/Buffer.js";
 import Geometry from "../geometry/Geometry.js";
 import InterleaveInfo from "../geometry/InterleaveInfo.js";

--- a/src/primitives/Plane.js
+++ b/src/primitives/Plane.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import Buffer from "../buffer/Buffer.js";
 import Geometry from "../geometry/Geometry.js";
 import InterleaveInfo from "../geometry/InterleaveInfo.js";

--- a/src/primitives/Sphere.js
+++ b/src/primitives/Sphere.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import Buffer from "../buffer/Buffer.js";
 import Geometry from "../geometry/Geometry.js";
 import InterleaveInfo from "../geometry/InterleaveInfo.js";

--- a/src/renderer/system/Debugger.js
+++ b/src/renderer/system/Debugger.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.1.16 11:31:50
  *
  */
-"use strict";
 let info;
 let _visible = false;
 let debuggerBox;

--- a/src/renderer/system/FinalRender.js
+++ b/src/renderer/system/FinalRender.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import BaseMaterial from "../../base/BaseMaterial.js";
 import ShareGLSL from "../../base/ShareGLSL.js";
 import BasePostEffect from "../../base/BasePostEffect.js";
@@ -31,7 +30,7 @@ export default class FinalRender extends BasePostEffect {
 	void main() {
 		// gl_Position = systemUniforms.perspectiveMTX * systemUniforms.cameraMTX * meshMatrixUniforms.modelMatrix[ int(meshUniforms.index) ] * vec4(position,1.0);
 		gl_Position = vertexUniforms.projectionMatrix * vec4(position,1.0);
-		
+
 		vNormal = normal;
 		vUV = uv;
 	}
@@ -45,7 +44,7 @@ export default class FinalRender extends BasePostEffect {
 	layout( location = 0 ) out vec4 outColor;
 	void main() {
 		vec4 diffuseColor = vec4(0.0);
-	
+
 		diffuseColor = texture( sampler2D( uSourceTexture, uSampler ), vUV ) ;
 		// diffuseColor.a = 0.5;
 

--- a/src/renderer/system/MouseEventChecker.js
+++ b/src/renderer/system/MouseEventChecker.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 
 import UUID from "../../base/UUID.js";
 

--- a/src/resources/BitmapCubeTexture.js
+++ b/src/resources/BitmapCubeTexture.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.1.10 20:9:14
  *
  */
-"use strict";
 import Sampler from "./Sampler.js";
 import ImageLoader from "./system/ImageLoader.js";
 import BitmapTexture from "./BitmapTexture.js";

--- a/src/resources/BitmapTexture.js
+++ b/src/resources/BitmapTexture.js
@@ -5,7 +5,6 @@
  *   Last modification time of this file - 2020.1.9 14:4:9
  *
  */
-"use strict";
 import generateWebGPUTextureMipmap from "./mipmapGenerator/generateWebGPUTextureMipmap";
 import Sampler from "./Sampler.js";
 import ImageLoader from "./system/ImageLoader.js";

--- a/src/resources/Sampler.js
+++ b/src/resources/Sampler.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 const TABLE = {};
 export default class Sampler {
   constructor(redGPUContext, option = {}) {

--- a/src/resources/TypeSize.js
+++ b/src/resources/TypeSize.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 let TypeSize = {
   'float32': 1 * Float32Array.BYTES_PER_ELEMENT,
   'float32x2': 2 * Float32Array.BYTES_PER_ELEMENT,

--- a/src/resources/system/ImageLoader.js
+++ b/src/resources/system/ImageLoader.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import UUID from "../../base/UUID.js";
 import RedGPUWorker from "../../base/RedGPUWorker.js";
 

--- a/src/util/UTIL.js
+++ b/src/util/UTIL.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import UTILColor from './func/UTILColor.js';
 import UTILMath from './func/UTILMath.js';
 import glMatrix from '../base/gl-matrix-min.js';

--- a/src/util/func/UTILColor.js
+++ b/src/util/func/UTILColor.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 import UTIL from "../UTIL.js";
 
 export default {

--- a/src/util/func/UTILMath.js
+++ b/src/util/func/UTILMath.js
@@ -6,7 +6,6 @@
  *
  */
 
-"use strict";
 let clamp = function (value, min, max) {
   return Math.max(min, Math.min(max, value));
 };


### PR DESCRIPTION
The modules use [strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode) automatically, so there is no need to write "use strict" in the module.
See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#other_differences_between_modules_and_standard_scripts

Trailing spaces, unused variables and imports are removed.