### PR TITLE
Remove Line2D examples from exampleList.js

### DIFF
--- a/examples/exampleHelper/exampleList/exampleList.js
+++ b/examples/exampleHelper/exampleList/exampleList.js
@@ -1304,35 +1304,7 @@ const ExampleList = [
                     },
                 ]
             },
-            {
-                name: 'Line2D',
-                list: [
-                    {
-                        name: 'Linear Type',
-                        path: '2d/line2D/linear',
-                        description: {
-                            ko: ``,
-                            en: ``
-                        },
-                    },
-                    {
-                        name: 'Bezier Type',
-                        path: '2d/line2D/bezier',
-                        description: {
-                            ko: ``,
-                            en: ``
-                        },
-                    },
-                    {
-                        name: 'CatmullRom Type',
-                        path: '2d/line2D/catmullRom',
-                        description: {
-                            ko: ``,
-                            en: ``
-                        },
-                    },
-                ]
-            },
+
 
             {
                 name: '2D Object Opacity',


### PR DESCRIPTION
The Line2D examples, including Linear, Bezier, and CatmullRom types, have been entirely removed from the exampleList. This simplifies the structure and eliminates unnecessary entries related to 2D line types.